### PR TITLE
chore: use npm Trusted Publishers for CI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,5 +49,4 @@ jobs:
           title: 'chore: release packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- npm Trusted Publishers を使用するように変更
- NPM_TOKEN の代わりに OIDC 認証を使用

## Test plan
- [ ] CI が通ることを確認
- [ ] マージ後に npm publish が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)