### PR TITLE
fix: add provenance config for npm Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/packages/avatar-optimizer/package.json
+++ b/packages/avatar-optimizer/package.json
@@ -36,7 +36,8 @@
   "author": "HALBY",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@gltf-transform/core": "^4.0.0",

--- a/packages/mtoon-atlas/package.json
+++ b/packages/mtoon-atlas/package.json
@@ -55,7 +55,8 @@
   "author": "HALBY",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "packageManager": "pnpm@10.22.0",
   "dependencies": {


### PR DESCRIPTION
## Summary
- 各パッケージの `publishConfig` に `provenance: true` を追加
- `registry-url` を復元

## Test plan
- [ ] マージ後に npm publish が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)