### PR TITLE
fix: setup npmrc for Trusted Publishers OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,17 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
+
+      - name: Setup npm for publishing
+        run: |
+          echo "//registry.npmjs.org/:_authToken=" >> ~/.npmrc
+          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
## Summary
- `registry-url` を削除して `.npmrc` を手動で設定
- Trusted Publishers の OIDC 認証が正しく動作するように修正

Ref: https://github.com/changesets/changesets/issues/1802

## Test plan
- [ ] マージ後に npm publish が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)