### PR TITLE
fix: exclude README.md from changeset detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Check for changesets
         id: check
         run: |
-          if ls .changeset/*.md 1> /dev/null 2>&1; then
+          # README.md と config.json 以外の .md ファイルがあるかチェック
+          CHANGESETS=$(find .changeset -name "*.md" ! -name "README.md" 2>/dev/null | head -1)
+          if [ -n "$CHANGESETS" ]; then
             echo "has_changesets=true" >> $GITHUB_OUTPUT
           else
             echo "has_changesets=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- changeset 検出時に README.md を除外するように修正
- これにより publish ステップが正しく実行される

## Test plan
- [ ] マージ後に npm publish が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)