### PR TITLE
fix: update npm to latest for Trusted Publishers OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm for Trusted Publishers
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- npm を最新バージョンに更新（Trusted Publishers の OIDC 認証には npm 11.5.1+ が必要）

Ref: https://www.k8o.me/blog/npm-trusted-publishing-for-npm-packages

## Test plan
- [ ] マージ後に npm publish が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)