### PR TITLE
fix: add repository field and use changesets/action for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,52 +42,13 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Check for changesets
-        id: check
-        run: |
-          # README.md と config.json 以外の .md ファイルがあるかチェック
-          CHANGESETS=$(find .changeset -name "*.md" ! -name "README.md" 2>/dev/null | head -1)
-          if [ -n "$CHANGESETS" ]; then
-            echo "has_changesets=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_changesets=false" >> $GITHUB_OUTPUT
-          fi
-
-      # changeset がある場合: Release PR を作成
-      - name: Create Release Pull Request
-        if: steps.check.outputs.has_changesets == 'true'
+      - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
           version: pnpm changeset:version
+          publish: pnpm changeset:publish
           commit: 'chore: release packages'
           title: 'chore: release packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-
-      # changeset がない場合: npm に publish（未公開バージョンのみ）
-      - name: Publish to npm
-        if: steps.check.outputs.has_changesets == 'false'
-        run: |
-          for pkg in packages/*/; do
-            if [ -f "$pkg/package.json" ]; then
-              name=$(node -p "require('./$pkg/package.json').name")
-              version=$(node -p "require('./$pkg/package.json').version")
-              private=$(node -p "require('./$pkg/package.json').private || false")
-
-              if [ "$private" = "true" ]; then
-                echo "Skipping $name (private)"
-                continue
-              fi
-
-              # npm に公開済みかチェック
-              published=$(npm view "$name@$version" version 2>/dev/null || echo "")
-              if [ -z "$published" ]; then
-                echo "Publishing $name@$version"
-                (cd "$pkg" && npm publish --access public --provenance)
-              else
-                echo "Skipping $name@$version (already published)"
-              fi
-            fi
-          done
-        env:
           NPM_CONFIG_PROVENANCE: true

--- a/packages/avatar-optimizer/package.json
+++ b/packages/avatar-optimizer/package.json
@@ -35,6 +35,11 @@
   ],
   "author": "HALBY",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webxr-jp/avatar-optimizer.git",
+    "directory": "packages/avatar-optimizer"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/mtoon-atlas/package.json
+++ b/packages/mtoon-atlas/package.json
@@ -54,6 +54,11 @@
   ],
   "author": "HALBY",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webxr-jp/avatar-optimizer.git",
+    "directory": "packages/mtoon-atlas"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
## Summary
- 各パッケージに `repository` フィールドを追加
- `changesets/action` を使った publish に戻す
- npm 最新版 + repository フィールドで Trusted Publishers が動作するはず

Ref: https://www.k8o.me/blog/npm-trusted-publishing-for-npm-packages

## Test plan
- [ ] マージ後に npm publish が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)