### PR TITLE
fix: match repository URL case with GitHub

### DIFF
--- a/packages/avatar-optimizer/package.json
+++ b/packages/avatar-optimizer/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/webxr-jp/avatar-optimizer.git",
+    "url": "https://github.com/WebXR-JP/avatar-optimizer.git",
     "directory": "packages/avatar-optimizer"
   },
   "publishConfig": {

--- a/packages/mtoon-atlas/package.json
+++ b/packages/mtoon-atlas/package.json
@@ -56,7 +56,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/webxr-jp/avatar-optimizer.git",
+    "url": "https://github.com/WebXR-JP/avatar-optimizer.git",
     "directory": "packages/mtoon-atlas"
   },
   "publishConfig": {

--- a/packages/texture-compression/package.json
+++ b/packages/texture-compression/package.json
@@ -37,8 +37,14 @@
   ],
   "author": "HALBY",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WebXR-JP/avatar-optimizer.git",
+    "directory": "packages/texture-compression"
+  },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",


### PR DESCRIPTION
## Summary
- `repository.url` の大文字小文字を GitHub と一致させる
- `webxr-jp` → `WebXR-JP`
- `texture-compression` にも `repository` フィールドと `provenance` を追加

## Test plan
- [ ] マージ後に npm publish が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)