### PR TITLE
fix: パッチで適用していた修正をソースに反映

### DIFF
--- a/packages/avatar-optimizer/src/avatar-optimizer.ts
+++ b/packages/avatar-optimizer/src/avatar-optimizer.ts
@@ -1,6 +1,6 @@
 import { MToonMaterial, VRM } from '@pixiv/three-vrm'
 import { ok, ResultAsync, safeTry } from 'neverthrow'
-import { Bone, BufferAttribute, Mesh } from 'three'
+import { Bone, BufferAttribute, Mesh, SkinnedMesh } from 'three'
 import { generateAtlasImagesFromPatterns } from './process/gen-atlas'
 import { buildPatternMaterialMappings, pack } from './process/packing'
 import { applyPlacementsToGeometries } from './process/set-uv'
@@ -38,159 +38,214 @@ export function optimizeModel(
     vrm.springBoneManager?.reset()
 
     // モデルのマテリアル集計（アウトライン情報を含む）
-    const materialInfos = yield* getMToonMaterialInfoFromObject3D(rootNode)
-    const materials = materialInfos.map((info) => info.material)
+    const materialInfoResult = getMToonMaterialInfoFromObject3D(rootNode)
 
-    // 後方互換性のためのMap生成
-    const materialMeshMap = new Map<MToonMaterial, Mesh[]>()
-    for (const info of materialInfos) {
-      materialMeshMap.set(info.material, info.meshes)
-    }
-
-    // マテリアルで使われてるテクスチャの組のパターンを集計
-    const patternMappings = buildPatternMaterialMappings(materials)
-
-    // パッキングレイアウトを構築
-    const packLayouts = yield* await pack(patternMappings)
-
-    // パターンごとのアトラス画像を生成
-    const atlasMap = yield* generateAtlasImagesFromPatterns(
-      materials,
-      patternMappings,
-      packLayouts.packed,
-      options.atlas,
-    )
-
-    // アトラス画像をマテリアルにそれぞれアサインする
-    const materialPlacementMap = new Map<MToonMaterial, OffsetScale>()
-    patternMappings.forEach((mapping, index) => {
-      const placement = packLayouts.packed[index]
-      for (const materialIndex of mapping.materialIndices) {
-        const material = materials[materialIndex]
-        assignAtlasTexturesToMaterial(material, atlasMap)
-        materialPlacementMap.set(material, placement)
-      }
-    })
-
-    // アトラス画像をマテリアルにそれぞれアサインする
-    // アトラス画像の配置に合わせてUVを移動する
-    yield* applyPlacementsToGeometries(rootNode, materialPlacementMap)
-
-    // 顔メッシュ（表情で使われているメッシュ）を特定
-    // 簡略化とメッシュ統合から除外するメッシュのSet
     const excludedMeshes = new Set<Mesh>()
-    if (vrm.expressionManager) {
-      for (const expression of vrm.expressionManager.expressions) {
-        for (const bind of expression.binds) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const bindAny = bind as any
+    let simplifyStats: SimplifyStatistics | undefined
+    let combineResult: CombinedMeshResult
 
-          // MorphTargetBind
-          if (bindAny.primitives) {
-            for (const mesh of bindAny.primitives) {
-              if (mesh && mesh.isMesh) {
-                excludedMeshes.add(mesh)
+    if (materialInfoResult.isOk()) {
+      const materialInfos = materialInfoResult.value
+      const materials = materialInfos.map((info) => info.material)
+
+      // 後方互換性のためのMap生成
+      const materialMeshMap = new Map<MToonMaterial, Mesh[]>()
+      for (const info of materialInfos) {
+        materialMeshMap.set(info.material, info.meshes)
+      }
+
+      // マテリアルで使われてるテクスチャの組のパターンを集計
+      const patternMappings = buildPatternMaterialMappings(materials)
+
+      // パッキングレイアウトを構築
+      const packLayouts = yield* await pack(patternMappings)
+
+      // パターンごとのアトラス画像を生成
+      const atlasMap = yield* generateAtlasImagesFromPatterns(
+        materials,
+        patternMappings,
+        packLayouts.packed,
+        options.atlas,
+      )
+
+      // アトラス画像をマテリアルにそれぞれアサインする
+      const materialPlacementMap = new Map<MToonMaterial, OffsetScale>()
+      patternMappings.forEach((mapping, index) => {
+        const placement = packLayouts.packed[index]
+        for (const materialIndex of mapping.materialIndices) {
+          const material = materials[materialIndex]
+          assignAtlasTexturesToMaterial(material, atlasMap)
+          materialPlacementMap.set(material, placement)
+        }
+      })
+
+      // アトラス画像の配置に合わせてUVを移動する
+      yield* applyPlacementsToGeometries(rootNode, materialPlacementMap)
+
+      // 顔メッシュ（表情で使われているメッシュ）を特定
+      // 簡略化とメッシュ統合から除外するメッシュのSet
+      if (vrm.expressionManager) {
+        for (const expression of vrm.expressionManager.expressions) {
+          for (const bind of expression.binds) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const bindAny = bind as any
+
+            // MorphTargetBind
+            if (bindAny.primitives) {
+              for (const mesh of bindAny.primitives) {
+                if (mesh && mesh.isMesh) {
+                  excludedMeshes.add(mesh)
+                }
+              }
+            }
+
+            // MaterialColorBind / TextureTransformBind
+            if (bindAny.material) {
+              const meshes = materialMeshMap.get(bindAny.material)
+              if (meshes) {
+                meshes.forEach((mesh) => excludedMeshes.add(mesh))
               }
             }
           }
+        }
+      }
 
-          // MaterialColorBind / TextureTransformBind
-          if (bindAny.material) {
-            const meshes = materialMeshMap.get(bindAny.material)
-            if (meshes) {
-              meshes.forEach((mesh) => excludedMeshes.add(mesh))
+      // 非SkinnedMeshはメッシュ統合から除外（ボーンペアレントを保持するため）
+      for (const meshes of materialMeshMap.values()) {
+        for (const mesh of meshes) {
+          if (!(mesh instanceof SkinnedMesh)) {
+            excludedMeshes.add(mesh)
+          }
+        }
+      }
+
+      // メッシュ簡略化（オプションが設定されている場合）
+      // UVリマッピング後、メッシュ統合前に実行
+      if (options.simplify) {
+        simplifyStats = yield* await simplifyMeshes(
+          rootNode,
+          excludedMeshes,
+          options.simplify,
+        )
+      }
+
+      // 複数のMesh及びMToonMaterialを統合してドローコール数を削減
+      // レンダーモード（opaque/alphaTest/transparent）ごとに別メッシュとして結合
+      combineResult = yield* combineMeshAndMaterial(
+        materialInfos,
+        {},
+        excludedMeshes,
+      )
+
+      // excludedMeshesにもMToonAtlasMaterialを適用
+      // これにより、エクスポート→インポート後も正しくレンダリングされる
+      // 最初のグループからスロット属性名を取得
+      const firstGroup = combineResult.groups.values().next().value
+      const slotAttributeName =
+        firstGroup?.material.slotAttribute?.name || 'mtoonMaterialSlot'
+
+      for (const mesh of excludedMeshes) {
+        // メッシュのマテリアルを取得
+        const originalMaterial = Array.isArray(mesh.material)
+          ? mesh.material[0]
+          : mesh.material
+
+        if (!(originalMaterial instanceof MToonMaterial)) continue
+
+        // スロット情報を取得
+        const slotInfo = combineResult.materialSlotIndex.get(originalMaterial)
+        if (!slotInfo) continue
+
+        // 対応するレンダーモードのグループを取得
+        const group = combineResult.groups.get(slotInfo.renderMode)
+        if (!group) continue
+
+        // ジオメトリにスロット属性を追加
+        const geometry = mesh.geometry
+        const vertexCount = geometry.getAttribute('position').count
+        const slotArray = new Float32Array(vertexCount).fill(slotInfo.slotIndex)
+        geometry.setAttribute(
+          slotAttributeName,
+          new BufferAttribute(slotArray, 1),
+        )
+
+        // MToonAtlasMaterialを適用（同じレンダーモードのマテリアルを共有）
+        mesh.material = group.material
+      }
+
+      // 元のrootNodeから既存のメッシュを削除
+      const meshesToRemove: Mesh[] = []
+      for (const meshes of materialMeshMap.values()) {
+        for (const mesh of meshes) {
+          if (!excludedMeshes.has(mesh)) {
+            meshesToRemove.push(mesh)
+          }
+        }
+      }
+
+      // 最初のメッシュの親を取得（結合後のメッシュを同じ親に追加するため）
+      const firstMeshParent = meshesToRemove[0]?.parent || rootNode
+
+      meshesToRemove.forEach((mesh) => mesh.parent?.remove(mesh))
+
+      // バッファを削除
+      for (const mesh of meshesToRemove) {
+        deleteMesh(mesh)
+      }
+
+      // 各レンダーモードのメッシュをシーンに追加
+      // アウトラインメッシュを先に追加することで、glTF/VRMエクスポート後も
+      // 正しい描画順序を維持（ノードの順序が描画順序に影響するため）
+      for (const group of combineResult.groups.values()) {
+        // アウトラインを先に追加（先に描画される = 後ろに表示される）
+        if (group.outlineMesh) {
+          firstMeshParent.add(group.outlineMesh)
+        }
+        // excludedMeshes専用グループの場合はmeshがnull
+        if (group.mesh) {
+          firstMeshParent.add(group.mesh)
+        }
+      }
+
+      // 簡略化統計を結果に追加
+      if (simplifyStats) {
+        combineResult.statistics.simplify = simplifyStats
+      }
+    } else {
+      // MToonMaterialがない場合: アトラス化・マテリアル統合をスキップ
+      if (vrm.expressionManager) {
+        for (const expression of vrm.expressionManager.expressions) {
+          for (const bind of expression.binds) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const bindAny = bind as any
+            if (bindAny.primitives) {
+              for (const mesh of bindAny.primitives) {
+                if (mesh && mesh.isMesh) {
+                  excludedMeshes.add(mesh)
+                }
+              }
             }
           }
         }
       }
-    }
 
-    // メッシュ簡略化（オプションが設定されている場合）
-    // UVリマッピング後、メッシュ統合前に実行
-    let simplifyStats: SimplifyStatistics | undefined
-    if (options.simplify) {
-      simplifyStats = yield* await simplifyMeshes(
-        rootNode,
-        excludedMeshes,
-        options.simplify,
-      )
-    }
-
-    // 複数のMesh及びMToonMaterialを統合してドローコール数を削減
-    // レンダーモード（opaque/alphaTest/transparent）ごとに別メッシュとして結合
-    const combineResult = yield* combineMeshAndMaterial(
-      materialInfos,
-      {},
-      excludedMeshes,
-    )
-
-    // excludedMeshesにもMToonAtlasMaterialを適用
-    // これにより、エクスポート→インポート後も正しくレンダリングされる
-    // 最初のグループからスロット属性名を取得
-    const firstGroup = combineResult.groups.values().next().value
-    const slotAttributeName =
-      firstGroup?.material.slotAttribute?.name || 'mtoonMaterialSlot'
-
-    for (const mesh of excludedMeshes) {
-      // メッシュのマテリアルを取得
-      const originalMaterial = Array.isArray(mesh.material)
-        ? mesh.material[0]
-        : mesh.material
-
-      if (!(originalMaterial instanceof MToonMaterial)) continue
-
-      // スロット情報を取得
-      const slotInfo = combineResult.materialSlotIndex.get(originalMaterial)
-      if (!slotInfo) continue
-
-      // 対応するレンダーモードのグループを取得
-      const group = combineResult.groups.get(slotInfo.renderMode)
-      if (!group) continue
-
-      // ジオメトリにスロット属性を追加
-      const geometry = mesh.geometry
-      const vertexCount = geometry.getAttribute('position').count
-      const slotArray = new Float32Array(vertexCount).fill(slotInfo.slotIndex)
-      geometry.setAttribute(
-        slotAttributeName,
-        new BufferAttribute(slotArray, 1),
-      )
-
-      // MToonAtlasMaterialを適用（同じレンダーモードのマテリアルを共有）
-      mesh.material = group.material
-    }
-
-    // 元のrootNodeから既存のメッシュを削除
-    const meshesToRemove: Mesh[] = []
-    for (const meshes of materialMeshMap.values()) {
-      for (const mesh of meshes) {
-        if (!excludedMeshes.has(mesh)) {
-          meshesToRemove.push(mesh)
-        }
+      if (options.simplify) {
+        simplifyStats = yield* await simplifyMeshes(
+          rootNode,
+          excludedMeshes,
+          options.simplify,
+        )
       }
-    }
 
-    // 最初のメッシュの親を取得（結合後のメッシュを同じ親に追加するため）
-    const firstMeshParent = meshesToRemove[0]?.parent || rootNode
-
-    meshesToRemove.forEach((mesh) => mesh.parent?.remove(mesh))
-
-    // バッファを削除
-    for (const mesh of meshesToRemove) {
-      deleteMesh(mesh)
-    }
-
-    // 各レンダーモードのメッシュをシーンに追加
-    // アウトラインメッシュを先に追加することで、glTF/VRMエクスポート後も
-    // 正しい描画順序を維持（ノードの順序が描画順序に影響するため）
-    for (const group of combineResult.groups.values()) {
-      // アウトラインを先に追加（先に描画される = 後ろに表示される）
-      if (group.outlineMesh) {
-        firstMeshParent.add(group.outlineMesh)
-      }
-      // excludedMeshes専用グループの場合はmeshがnull
-      if (group.mesh) {
-        firstMeshParent.add(group.mesh)
+      combineResult = {
+        groups: new Map(),
+        materialSlotIndex: new Map(),
+        statistics: {
+          originalMeshCount: 0,
+          originalMaterialCount: 0,
+          reducedDrawCalls: 0,
+          simplify: simplifyStats,
+        },
       }
     }
 
@@ -235,11 +290,6 @@ export function optimizeModel(
       // - コライダーオフセットをY軸180度回転
       // - SpringBoneの初期状態を再設定
       migrateSpringBone(vrm)
-    }
-
-    // 簡略化統計を結果に追加
-    if (simplifyStats) {
-      combineResult.statistics.simplify = simplifyStats
     }
 
     return ok(combineResult)

--- a/packages/avatar-optimizer/src/process/gen-atlas.ts
+++ b/packages/avatar-optimizer/src/process/gen-atlas.ts
@@ -105,12 +105,6 @@ export function generateAtlasImagesFromPatterns(
     for (const slot of MTOON_TEXTURE_SLOTS) {
       const layers: ImageMatrixPair[] = []
 
-      // このスロットに1つでもテクスチャを持つマテリアルがあるかチェック
-      const anyTextureExists = patternMappings.some((mapping) => {
-        const material = materials[mapping.materialIndices[0]]
-        return material[slot] != null
-      })
-
       // 各パターンについて、最初のマテリアルからテクスチャを取得
       for (let i = 0; i < patternMappings.length; i++) {
         const mapping = patternMappings[i]
@@ -126,7 +120,7 @@ export function generateAtlasImagesFromPatterns(
             image: texture,
             uvTransform: placement,
           })
-        } else if (anyTextureExists) {
+        } else {
           // テクスチャを持たないマテリアルにはデフォルト色のダミーテクスチャを生成
           // アトラスの該当領域が黒(0,0,0,0)のまま残ることを防ぐ
           const [r, g, b, a] = SLOT_DEFAULT_FILL[slot]


### PR DESCRIPTION
## Summary
- xrift-frontendの`patch-package`で適用していた3つの修正をavatar-optimizerのソースコードに反映
- リリース後、xrift-frontend側のパッチファイル（`patches/@webxr-jp+avatar-optimizer+0.1.4.patch`）を削除可能になる

## 変更内容

### 1. テクスチャなしMToonマテリアルのカラー反映（gen-atlas.ts）
- `anyTextureExists`条件を削除し、テクスチャを持たないマテリアルにも常にデフォルト色のダミーテクスチャを生成
- テクスチャなしマテリアルのアトラス領域が黒(0,0,0,0)で埋まる問題を修正

### 2. 非SkinnedMeshのメッシュ統合除外（avatar-optimizer.ts）
- `SkinnedMesh`以外のMesh（ボーンペアレントのMeshなど）を`excludedMeshes`に追加
- メッシュ統合時にボーンペアレントが破壊される問題を防止

### 3. MToonMaterialがないモデルのハンドリング（avatar-optimizer.ts）
- `getMToonMaterialInfoFromObject3D`の結果を`Result`型で分岐処理
- MToonMaterialがないモデルではアトラス化・マテリアル統合をスキップし、簡略化のみ実行

## Test plan
- [ ] テクスチャなしMToonマテリアルを含むVRMでカラーが正しく反映されるか確認
- [ ] 非SkinnedMesh（ボーンペアレントMesh）を含むVRMで統合後に位置ズレがないか確認
- [ ] MToonMaterialを持たないVRMで最適化がエラーなく完了するか確認
- [ ] 通常のVRM（全MToon・全SkinnedMesh）で既存動作に影響がないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)