### PR TITLE
refactor: 純粋関数の切り出しとユニットテスト追加

### DIFF
--- a/packages/avatar-optimizer/src/avatar-optimizer.ts
+++ b/packages/avatar-optimizer/src/avatar-optimizer.ts
@@ -1,6 +1,6 @@
 import { MToonMaterial, VRM } from '@pixiv/three-vrm'
 import { ok, ResultAsync, safeTry } from 'neverthrow'
-import { Bone, BufferAttribute, Mesh, SkinnedMesh } from 'three'
+import { Bone, BufferAttribute, Mesh } from 'three'
 import { generateAtlasImagesFromPatterns } from './process/gen-atlas'
 import { buildPatternMaterialMappings, pack } from './process/packing'
 import { applyPlacementsToGeometries } from './process/set-uv'
@@ -13,6 +13,11 @@ import {
   getMToonMaterialInfoFromObject3D,
 } from './util/material'
 import { deleteMesh } from './util/mesh/deleter'
+import {
+  collectExpressionMeshes,
+  collectNonSkinnedMeshes,
+  createEmptyCombinedMeshResult,
+} from './util/optimize-helpers'
 import { migrateSkeletonVRM0ToVRM1 } from './util/skeleton'
 import { migrateSpringBone } from './util/springbone'
 
@@ -84,39 +89,16 @@ export function optimizeModel(
 
       // 顔メッシュ（表情で使われているメッシュ）を特定
       // 簡略化とメッシュ統合から除外するメッシュのSet
-      if (vrm.expressionManager) {
-        for (const expression of vrm.expressionManager.expressions) {
-          for (const bind of expression.binds) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const bindAny = bind as any
-
-            // MorphTargetBind
-            if (bindAny.primitives) {
-              for (const mesh of bindAny.primitives) {
-                if (mesh && mesh.isMesh) {
-                  excludedMeshes.add(mesh)
-                }
-              }
-            }
-
-            // MaterialColorBind / TextureTransformBind
-            if (bindAny.material) {
-              const meshes = materialMeshMap.get(bindAny.material)
-              if (meshes) {
-                meshes.forEach((mesh) => excludedMeshes.add(mesh))
-              }
-            }
-          }
-        }
+      for (const mesh of collectExpressionMeshes(
+        vrm.expressionManager ?? null,
+        materialMeshMap,
+      )) {
+        excludedMeshes.add(mesh)
       }
 
       // 非SkinnedMeshはメッシュ統合から除外（ボーンペアレントを保持するため）
-      for (const meshes of materialMeshMap.values()) {
-        for (const mesh of meshes) {
-          if (!(mesh instanceof SkinnedMesh)) {
-            excludedMeshes.add(mesh)
-          }
-        }
+      for (const mesh of collectNonSkinnedMeshes(materialMeshMap)) {
+        excludedMeshes.add(mesh)
       }
 
       // メッシュ簡略化（オプションが設定されている場合）
@@ -213,20 +195,10 @@ export function optimizeModel(
       }
     } else {
       // MToonMaterialがない場合: アトラス化・マテリアル統合をスキップ
-      if (vrm.expressionManager) {
-        for (const expression of vrm.expressionManager.expressions) {
-          for (const bind of expression.binds) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const bindAny = bind as any
-            if (bindAny.primitives) {
-              for (const mesh of bindAny.primitives) {
-                if (mesh && mesh.isMesh) {
-                  excludedMeshes.add(mesh)
-                }
-              }
-            }
-          }
-        }
+      for (const mesh of collectExpressionMeshes(
+        vrm.expressionManager ?? null,
+      )) {
+        excludedMeshes.add(mesh)
       }
 
       if (options.simplify) {
@@ -237,16 +209,7 @@ export function optimizeModel(
         )
       }
 
-      combineResult = {
-        groups: new Map(),
-        materialSlotIndex: new Map(),
-        statistics: {
-          originalMeshCount: 0,
-          originalMaterialCount: 0,
-          reducedDrawCalls: 0,
-          simplify: simplifyStats,
-        },
-      }
+      combineResult = createEmptyCombinedMeshResult(simplifyStats)
     }
 
     // VRM0.x -> VRM1.0 スケルトンマイグレーション（メッシュ統合後に実行）

--- a/packages/avatar-optimizer/src/process/gen-atlas.ts
+++ b/packages/avatar-optimizer/src/process/gen-atlas.ts
@@ -29,7 +29,7 @@ const DEFAULT_ATLAS_RESOLUTION = 2048
  * テクスチャを持たないマテリアルがアトラス内で黒(0,0,0,0)にならないよう、
  * 各スロットの「無影響」な中立色でダミーテクスチャを生成する
  */
-const SLOT_DEFAULT_FILL: Record<MToonTextureSlot, readonly [number, number, number, number]> = {
+export const SLOT_DEFAULT_FILL: Record<MToonTextureSlot, readonly [number, number, number, number]> = {
   map: [255, 255, 255, 255], // 乗算なので白=無影響
   shadeMultiplyTexture: [255, 255, 255, 255],
   emissiveMap: [0, 0, 0, 255], // 加算なので黒=発光なし
@@ -44,7 +44,7 @@ const SLOT_DEFAULT_FILL: Record<MToonTextureSlot, readonly [number, number, numb
 /**
  * 指定色で塗りつぶされた小さなDataTextureを生成する
  */
-function createSolidColorTexture(
+export function createSolidColorTexture(
   r: number,
   g: number,
   b: number,
@@ -77,6 +77,51 @@ function getSlotResolution(
 }
 
 /**
+ * 指定スロットについて、各パターンのイメージレイヤーを構築する
+ * テクスチャがないマテリアルにはSLOT_DEFAULT_FILLに基づくダミーテクスチャを生成
+ *
+ * @param materials - 全マテリアル配列
+ * @param patternMappings - パターンとマテリアルのマッピング
+ * @param patternPlacements - パターンごとのUV変換行列
+ * @param slot - 処理対象のテクスチャスロット
+ */
+export function buildLayersForSlot(
+  materials: MToonMaterial[],
+  patternMappings: PatternMaterialMapping[],
+  patternPlacements: OffsetScale[],
+  slot: MToonTextureSlot,
+): ImageMatrixPair[] {
+  const layers: ImageMatrixPair[] = []
+
+  for (let i = 0; i < patternMappings.length; i++) {
+    const mapping = patternMappings[i]
+    const placement = patternPlacements[i]
+
+    // このパターンの最初のマテリアルを代表として使用
+    const representativeMaterialIndex = mapping.materialIndices[0]
+    const material = materials[representativeMaterialIndex]
+
+    const texture = material[slot]
+    if (texture) {
+      layers.push({
+        image: texture,
+        uvTransform: placement,
+      })
+    } else {
+      // テクスチャを持たないマテリアルにはデフォルト色のダミーテクスチャを生成
+      // アトラスの該当領域が黒(0,0,0,0)のまま残ることを防ぐ
+      const [r, g, b, a] = SLOT_DEFAULT_FILL[slot]
+      layers.push({
+        image: createSolidColorTexture(r, g, b, a),
+        uvTransform: placement,
+      })
+    }
+  }
+
+  return layers
+}
+
+/**
  * テクスチャ組み合わせパターンに基づいてアトラス画像を生成
  * 各スロットごとに、一意なパターンのテクスチャのみをアトラス化
  *
@@ -103,33 +148,12 @@ export function generateAtlasImagesFromPatterns(
     const atlasMap: Partial<AtlasImageMap> = {}
 
     for (const slot of MTOON_TEXTURE_SLOTS) {
-      const layers: ImageMatrixPair[] = []
-
-      // 各パターンについて、最初のマテリアルからテクスチャを取得
-      for (let i = 0; i < patternMappings.length; i++) {
-        const mapping = patternMappings[i]
-        const placement = patternPlacements[i]
-
-        // このパターンの最初のマテリアルを代表として使用
-        const representativeMaterialIndex = mapping.materialIndices[0]
-        const material = materials[representativeMaterialIndex]
-
-        const texture = material[slot]
-        if (texture) {
-          layers.push({
-            image: texture,
-            uvTransform: placement,
-          })
-        } else {
-          // テクスチャを持たないマテリアルにはデフォルト色のダミーテクスチャを生成
-          // アトラスの該当領域が黒(0,0,0,0)のまま残ることを防ぐ
-          const [r, g, b, a] = SLOT_DEFAULT_FILL[slot]
-          layers.push({
-            image: createSolidColorTexture(r, g, b, a),
-            uvTransform: placement,
-          })
-        }
-      }
+      const layers = buildLayersForSlot(
+        materials,
+        patternMappings,
+        patternPlacements,
+        slot,
+      )
 
       const resolution = getSlotResolution(slot, options)
       const atlas = yield* composeImagesToAtlas(layers, {

--- a/packages/avatar-optimizer/src/util/optimize-helpers.ts
+++ b/packages/avatar-optimizer/src/util/optimize-helpers.ts
@@ -1,0 +1,85 @@
+import type { MToonMaterial, VRMExpressionManager } from '@pixiv/three-vrm'
+import { Mesh, SkinnedMesh } from 'three'
+import type { SimplifyStatistics } from '../process/simplify'
+import type { CombinedMeshResult } from './material/types'
+
+/**
+ * materialMeshMap から非SkinnedMeshを収集する
+ * ボーンペアレントを保持するため、メッシュ統合から除外する必要がある
+ */
+export function collectNonSkinnedMeshes(
+  materialMeshMap: Map<MToonMaterial, Mesh[]>,
+): Set<Mesh> {
+  const result = new Set<Mesh>()
+  for (const meshes of materialMeshMap.values()) {
+    for (const mesh of meshes) {
+      if (!(mesh instanceof SkinnedMesh)) {
+        result.add(mesh)
+      }
+    }
+  }
+  return result
+}
+
+/**
+ * VRM expressionManager から除外メッシュを収集する
+ *
+ * - MorphTargetBind: primitives からメッシュを収集（常に）
+ * - MaterialColorBind / TextureTransformBind: materialMeshMap を使ってメッシュを収集（MToonあり時のみ）
+ *
+ * @param expressionManager - VRMのexpressionManager（nullの場合は空Setを返す）
+ * @param materialMeshMap - MToonMaterial→Mesh[]のマップ（MToonあり時に指定）
+ */
+export function collectExpressionMeshes(
+  expressionManager: VRMExpressionManager | null,
+  materialMeshMap?: Map<MToonMaterial, Mesh[]>,
+): Set<Mesh> {
+  const result = new Set<Mesh>()
+  if (!expressionManager) return result
+
+  for (const expression of expressionManager.expressions) {
+    for (const bind of expression.binds) {
+      // biome-ignore lint/suspicious/noExplicitAny: VRM internal bind types are not exported
+      const bindAny = bind as any
+
+      // MorphTargetBind
+      if (bindAny.primitives) {
+        for (const mesh of bindAny.primitives) {
+          if (mesh && mesh.isMesh) {
+            result.add(mesh)
+          }
+        }
+      }
+
+      // MaterialColorBind / TextureTransformBind（materialMeshMap指定時のみ）
+      if (materialMeshMap && bindAny.material) {
+        const meshes = materialMeshMap.get(bindAny.material)
+        if (meshes) {
+          for (const mesh of meshes) {
+            result.add(mesh)
+          }
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * MToonMaterialがない場合のダミーCombinedMeshResultを生成する
+ */
+export function createEmptyCombinedMeshResult(
+  simplifyStats?: SimplifyStatistics,
+): CombinedMeshResult {
+  return {
+    groups: new Map(),
+    materialSlotIndex: new Map(),
+    statistics: {
+      originalMeshCount: 0,
+      originalMaterialCount: 0,
+      reducedDrawCalls: 0,
+      simplify: simplifyStats,
+    },
+  }
+}

--- a/packages/avatar-optimizer/tests/process/gen-atlas.test.ts
+++ b/packages/avatar-optimizer/tests/process/gen-atlas.test.ts
@@ -1,0 +1,222 @@
+import { MToonMaterial } from '@pixiv/three-vrm'
+import { DataTexture, Texture, Vector2 } from 'three'
+import { describe, expect, it } from 'vitest'
+import {
+  buildLayersForSlot,
+  createSolidColorTexture,
+  SLOT_DEFAULT_FILL,
+} from '../../src/process/gen-atlas'
+import type { MToonTextureSlot, PatternMaterialMapping } from '../../src/types'
+
+/**
+ * テスト用のPatternMaterialMappingを作成するヘルパー
+ */
+function createMapping(materialIndices: number[]): PatternMaterialMapping {
+  return {
+    pattern: { slots: new Map() },
+    materialIndices,
+    textureDescriptor: { width: 512, height: 512 },
+  }
+}
+
+/**
+ * テスト用のOffsetScaleを作成するヘルパー
+ */
+function createPlacement(ox: number, oy: number, sx: number, sy: number) {
+  return { offset: new Vector2(ox, oy), scale: new Vector2(sx, sy) }
+}
+
+describe('gen-atlas', () => {
+  describe('buildLayersForSlot', () => {
+    it('テクスチャありの場合、そのテクスチャが返る', () => {
+      const tex = new Texture()
+      tex.image = { width: 512, height: 512 }
+
+      const mat = new MToonMaterial()
+      mat.map = tex
+
+      const materials = [mat]
+      const mappings = [createMapping([0])]
+      const placements = [createPlacement(0, 0, 1, 1)]
+
+      const layers = buildLayersForSlot(materials, mappings, placements, 'map')
+
+      expect(layers).toHaveLength(1)
+      expect(layers[0].image).toBe(tex)
+      expect(layers[0].uvTransform).toBe(placements[0])
+    })
+
+    it('テクスチャなしの場合、SLOT_DEFAULT_FILLに基づくダミーテクスチャが返る', () => {
+      const mat = new MToonMaterial()
+      // map テクスチャを設定しない
+
+      const materials = [mat]
+      const mappings = [createMapping([0])]
+      const placements = [createPlacement(0, 0, 0.5, 0.5)]
+
+      const layers = buildLayersForSlot(materials, mappings, placements, 'map')
+
+      expect(layers).toHaveLength(1)
+      // ダミーテクスチャが生成される（DataTexture）
+      expect(layers[0].image).toBeInstanceOf(DataTexture)
+      expect(layers[0].uvTransform).toBe(placements[0])
+
+      // mapのデフォルト色は白 [255, 255, 255, 255]
+      const dataTexture = layers[0].image as DataTexture
+      const data = dataTexture.image.data
+      expect(data[0]).toBe(255) // R
+      expect(data[1]).toBe(255) // G
+      expect(data[2]).toBe(255) // B
+      expect(data[3]).toBe(255) // A
+    })
+
+    it('テクスチャなしのemissiveMapスロットでは黒のダミーが返る', () => {
+      const mat = new MToonMaterial()
+
+      const layers = buildLayersForSlot(
+        [mat],
+        [createMapping([0])],
+        [createPlacement(0, 0, 1, 1)],
+        'emissiveMap',
+      )
+
+      expect(layers).toHaveLength(1)
+      const dataTexture = layers[0].image as DataTexture
+      const data = dataTexture.image.data
+      // emissiveMapのデフォルト色は [0, 0, 0, 255]
+      expect(data[0]).toBe(0)
+      expect(data[1]).toBe(0)
+      expect(data[2]).toBe(0)
+      expect(data[3]).toBe(255)
+    })
+
+    it('テクスチャなしのnormalMapスロットではフラット法線のダミーが返る', () => {
+      const mat = new MToonMaterial()
+
+      const layers = buildLayersForSlot(
+        [mat],
+        [createMapping([0])],
+        [createPlacement(0, 0, 1, 1)],
+        'normalMap',
+      )
+
+      expect(layers).toHaveLength(1)
+      const dataTexture = layers[0].image as DataTexture
+      const data = dataTexture.image.data
+      // normalMapのデフォルト色は [128, 128, 255, 255]（フラット法線）
+      expect(data[0]).toBe(128)
+      expect(data[1]).toBe(128)
+      expect(data[2]).toBe(255)
+      expect(data[3]).toBe(255)
+    })
+
+    it('混在（テクスチャあり・なし）の場合、両方正しく処理される', () => {
+      const tex = new Texture()
+      tex.image = { width: 256, height: 256 }
+
+      const matWithTex = new MToonMaterial()
+      matWithTex.map = tex
+
+      const matWithoutTex = new MToonMaterial()
+
+      const materials = [matWithTex, matWithoutTex]
+      const mappings = [createMapping([0]), createMapping([1])]
+      const placements = [
+        createPlacement(0, 0, 0.5, 0.5),
+        createPlacement(0.5, 0, 0.5, 0.5),
+      ]
+
+      const layers = buildLayersForSlot(
+        materials,
+        mappings,
+        placements,
+        'map',
+      )
+
+      expect(layers).toHaveLength(2)
+      // 最初のレイヤーはオリジナルテクスチャ
+      expect(layers[0].image).toBe(tex)
+      // 2番目のレイヤーはダミーテクスチャ
+      expect(layers[1].image).toBeInstanceOf(DataTexture)
+    })
+
+    it('複数マテリアルが同一パターンの場合、最初のマテリアルを代表として使用', () => {
+      const tex = new Texture()
+      tex.image = { width: 512, height: 512 }
+
+      const mat1 = new MToonMaterial()
+      mat1.map = tex
+      const mat2 = new MToonMaterial()
+      mat2.map = tex
+
+      const materials = [mat1, mat2]
+      // 両マテリアルが同一パターン
+      const mappings = [createMapping([0, 1])]
+      const placements = [createPlacement(0, 0, 1, 1)]
+
+      const layers = buildLayersForSlot(
+        materials,
+        mappings,
+        placements,
+        'map',
+      )
+
+      expect(layers).toHaveLength(1)
+      expect(layers[0].image).toBe(tex)
+    })
+  })
+
+  describe('SLOT_DEFAULT_FILL', () => {
+    it('全スロットにデフォルト色が定義されている', () => {
+      const expectedSlots: MToonTextureSlot[] = [
+        'map',
+        'shadeMultiplyTexture',
+        'emissiveMap',
+        'normalMap',
+        'shadingShiftTexture',
+        'matcapTexture',
+        'rimMultiplyTexture',
+        'outlineWidthMultiplyTexture',
+        'uvAnimationMaskTexture',
+      ]
+
+      for (const slot of expectedSlots) {
+        expect(SLOT_DEFAULT_FILL[slot]).toBeDefined()
+        expect(SLOT_DEFAULT_FILL[slot]).toHaveLength(4)
+      }
+    })
+
+    it('乗算スロットは白、加算スロットは黒がデフォルト', () => {
+      // 乗算スロット（白=無影響）
+      expect(SLOT_DEFAULT_FILL.map).toEqual([255, 255, 255, 255])
+      expect(SLOT_DEFAULT_FILL.shadeMultiplyTexture).toEqual([255, 255, 255, 255])
+      expect(SLOT_DEFAULT_FILL.rimMultiplyTexture).toEqual([255, 255, 255, 255])
+
+      // 加算スロット（黒=無影響）
+      expect(SLOT_DEFAULT_FILL.emissiveMap).toEqual([0, 0, 0, 255])
+    })
+  })
+
+  describe('createSolidColorTexture', () => {
+    it('指定色でDataTextureを生成する', () => {
+      const tex = createSolidColorTexture(128, 64, 32, 255)
+
+      expect(tex).toBeInstanceOf(DataTexture)
+      const data = (tex as DataTexture).image.data
+      // 4x4テクスチャ（デフォルト）なので16ピクセル
+      expect(data.length).toBe(4 * 4 * 4)
+      // 最初のピクセルを検証
+      expect(data[0]).toBe(128)
+      expect(data[1]).toBe(64)
+      expect(data[2]).toBe(32)
+      expect(data[3]).toBe(255)
+    })
+
+    it('カスタムサイズで生成できる', () => {
+      const tex = createSolidColorTexture(0, 0, 0, 255, 2, 2)
+
+      const data = (tex as DataTexture).image.data
+      expect(data.length).toBe(2 * 2 * 4)
+    })
+  })
+})

--- a/packages/avatar-optimizer/tests/process/optimize-helpers.test.ts
+++ b/packages/avatar-optimizer/tests/process/optimize-helpers.test.ts
@@ -1,0 +1,175 @@
+import { MToonMaterial } from '@pixiv/three-vrm'
+import {
+  BoxGeometry,
+  Mesh,
+  Skeleton,
+  SkinnedMesh,
+  Bone,
+} from 'three'
+import { describe, expect, it } from 'vitest'
+import {
+  collectExpressionMeshes,
+  collectNonSkinnedMeshes,
+  createEmptyCombinedMeshResult,
+} from '../../src/util/optimize-helpers'
+
+describe('optimize-helpers', () => {
+  describe('collectNonSkinnedMeshes', () => {
+    it('SkinnedMeshと通常Meshが混在する場合、通常Meshのみ返す', () => {
+      const mat = new MToonMaterial()
+      const geometry = new BoxGeometry()
+
+      const normalMesh = new Mesh(geometry, mat)
+      const bone = new Bone()
+      const skinnedMesh = new SkinnedMesh(geometry, mat)
+      skinnedMesh.bind(new Skeleton([bone]))
+
+      const materialMeshMap = new Map<MToonMaterial, Mesh[]>()
+      materialMeshMap.set(mat, [normalMesh, skinnedMesh])
+
+      const result = collectNonSkinnedMeshes(materialMeshMap)
+
+      expect(result.size).toBe(1)
+      expect(result.has(normalMesh)).toBe(true)
+      expect(result.has(skinnedMesh)).toBe(false)
+    })
+
+    it('全てSkinnedMeshの場合、空Setを返す', () => {
+      const mat = new MToonMaterial()
+      const geometry = new BoxGeometry()
+      const bone = new Bone()
+
+      const skinnedMesh1 = new SkinnedMesh(geometry, mat)
+      skinnedMesh1.bind(new Skeleton([bone]))
+      const skinnedMesh2 = new SkinnedMesh(geometry, mat)
+      skinnedMesh2.bind(new Skeleton([bone]))
+
+      const materialMeshMap = new Map<MToonMaterial, Mesh[]>()
+      materialMeshMap.set(mat, [skinnedMesh1, skinnedMesh2])
+
+      const result = collectNonSkinnedMeshes(materialMeshMap)
+
+      expect(result.size).toBe(0)
+    })
+
+    it('空Mapの場合、空Setを返す', () => {
+      const materialMeshMap = new Map<MToonMaterial, Mesh[]>()
+
+      const result = collectNonSkinnedMeshes(materialMeshMap)
+
+      expect(result.size).toBe(0)
+    })
+  })
+
+  describe('collectExpressionMeshes', () => {
+    it('expressionManagerがnullの場合、空Setを返す', () => {
+      const result = collectExpressionMeshes(null)
+
+      expect(result.size).toBe(0)
+    })
+
+    it('primitivesからメッシュを収集する', () => {
+      const mesh1 = new Mesh(new BoxGeometry())
+      const mesh2 = new Mesh(new BoxGeometry())
+
+      const mockExpressionManager = {
+        expressions: [
+          {
+            binds: [
+              { primitives: [mesh1, mesh2] },
+            ],
+          },
+        ],
+      }
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const result = collectExpressionMeshes(mockExpressionManager as any)
+
+      expect(result.size).toBe(2)
+      expect(result.has(mesh1)).toBe(true)
+      expect(result.has(mesh2)).toBe(true)
+    })
+
+    it('materialMeshMapありでMaterialColorBindのメッシュも収集する', () => {
+      const mat = new MToonMaterial()
+      const morphMesh = new Mesh(new BoxGeometry())
+      const materialMesh = new Mesh(new BoxGeometry())
+
+      const materialMeshMap = new Map<MToonMaterial, Mesh[]>()
+      materialMeshMap.set(mat, [materialMesh])
+
+      const mockExpressionManager = {
+        expressions: [
+          {
+            binds: [
+              { primitives: [morphMesh] },
+              { material: mat },
+            ],
+          },
+        ],
+      }
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const result = collectExpressionMeshes(
+        mockExpressionManager as any,
+        materialMeshMap,
+      )
+
+      expect(result.size).toBe(2)
+      expect(result.has(morphMesh)).toBe(true)
+      expect(result.has(materialMesh)).toBe(true)
+    })
+
+    it('materialMeshMap未指定時はMaterialColorBindを無視する', () => {
+      const mat = new MToonMaterial()
+      const morphMesh = new Mesh(new BoxGeometry())
+
+      const mockExpressionManager = {
+        expressions: [
+          {
+            binds: [
+              { primitives: [morphMesh] },
+              { material: mat },
+            ],
+          },
+        ],
+      }
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const result = collectExpressionMeshes(mockExpressionManager as any)
+
+      expect(result.size).toBe(1)
+      expect(result.has(morphMesh)).toBe(true)
+    })
+  })
+
+  describe('createEmptyCombinedMeshResult', () => {
+    it('simplifyStatsなしの場合、全フィールドが初期値', () => {
+      const result = createEmptyCombinedMeshResult()
+
+      expect(result.groups.size).toBe(0)
+      expect(result.materialSlotIndex.size).toBe(0)
+      expect(result.statistics.originalMeshCount).toBe(0)
+      expect(result.statistics.originalMaterialCount).toBe(0)
+      expect(result.statistics.reducedDrawCalls).toBe(0)
+      expect(result.statistics.simplify).toBeUndefined()
+    })
+
+    it('simplifyStatsありの場合、statisticsに反映される', () => {
+      const simplifyStats = {
+        processedMeshCount: 5,
+        skippedMeshCount: 2,
+        originalVertexCount: 10000,
+        simplifiedVertexCount: 5000,
+        originalIndexCount: 30000,
+        simplifiedIndexCount: 15000,
+      }
+
+      const result = createEmptyCombinedMeshResult(simplifyStats)
+
+      expect(result.statistics.simplify).toBe(simplifyStats)
+      expect(result.statistics.simplify?.processedMeshCount).toBe(5)
+      expect(result.statistics.simplify?.simplifiedVertexCount).toBe(5000)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- `avatar-optimizer.ts` と `gen-atlas.ts` から純粋関数を切り出し、テスト容易性と保守性を向上
- `collectNonSkinnedMeshes`: 非SkinnedMesh収集ロジック
- `collectExpressionMeshes`: VRM expression除外メッシュ収集（isOk/isErrブランチの重複コードを統合）
- `createEmptyCombinedMeshResult`: MToonなし時のダミー結果生成
- `buildLayersForSlot`: スロットごとのイメージレイヤー構築（テクスチャなしダミー生成を含む）
- `SLOT_DEFAULT_FILL`, `createSolidColorTexture` をexport化

## Test plan
- [x] `tests/process/optimize-helpers.test.ts` - 9テスト（3関数のユニットテスト）
- [x] `tests/process/gen-atlas.test.ts` - 10テスト（buildLayersForSlot, SLOT_DEFAULT_FILL, createSolidColorTexture）
- [x] 既存テスト全66件パス、リグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)