### PR TITLE
ci: ワークフローのNodeを24に更新（Release失敗の修正）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## 概要

PR #33 マージ後のReleaseワークフローが失敗し、リリースPRが作成されていない問題を修正します。

## 原因

`release.yml` の「Update npm for Trusted Publishers」ステップ（`npm install -g npm@latest`）が失敗:

```
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

最新のnpm 12がNode 20のサポートを打ち切ったため、`node-version: 20` を指定している限り恒久的に失敗します。Node 20自体もGitHub Actionsランナーで非推奨になっています。

## 修正内容

- `release.yml` / `ci.yml` の `node-version` を 20 → 24 に更新

## マージ後

mainへのpushで再度Releaseワークフローが走り、PR #33 のchangesetを含むリリースPR（`chore: release packages`）が自動作成されるはずです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)