### PR TITLE
fix: KTX2圧縮にsRGB転送関数の指定を追加（カラーテクスチャの白浮き修正）

### DIFF
--- a/.changeset/ktx2-srgb-transfer-func.md
+++ b/.changeset/ktx2-srgb-transfer-func.md
@@ -1,0 +1,6 @@
+---
+'@webxr-jp/texture-compression': patch
+'@webxr-jp/mtoon-atlas': patch
+---
+
+KTX2圧縮でsRGB転送関数が指定されず、カラーテクスチャがリニア扱いになり表示が白く浮く問題を修正。`Ktx2CompressionOptions`に`srgb`オプションを追加し、`MToonAtlasExporterPlugin`はテクスチャの`colorSpace`から自動判定して渡す

--- a/packages/mtoon-atlas/src/extensions/MToonAtlasExporterPlugin.ts
+++ b/packages/mtoon-atlas/src/extensions/MToonAtlasExporterPlugin.ts
@@ -1,4 +1,4 @@
-import { BufferAttribute, BufferGeometry, InterleavedBufferAttribute, Mesh, Object3D, SkinnedMesh, Texture } from 'three'
+import { BufferAttribute, BufferGeometry, InterleavedBufferAttribute, Mesh, Object3D, SkinnedMesh, SRGBColorSpace, Texture } from 'three'
 import { encode as encodePng16 } from 'fast-png'
 import { compressToKtx2 } from '@webxr-jp/texture-compression'
 import type { Ktx2CompressionOptions } from '@webxr-jp/texture-compression'
@@ -606,11 +606,15 @@ export class MToonAtlasExporterPlugin
     // extractRgbaDataで取得したデータはそのまま使用する
 
     // 圧縮オプションを構築
+    // srgb: カラーテクスチャ（map/shadeMultiply/emissive等、colorSpace=SRGB）は
+    // KTX2のDFD transferFunctionをsRGBにする。指定しないとリニア扱いになり、
+    // 実GPUのBC7/ASTC等トランスコード経路でsRGB変換が二重適用され白く浮く
     const compressionOptions: Ktx2CompressionOptions = {
       quality: this.textureCompressionOptions?.quality,
       compressionLevel: this.textureCompressionOptions?.compressionLevel,
       generateMipmaps: this.textureCompressionOptions?.generateMipmaps,
       supercompression: this.textureCompressionOptions?.supercompression,
+      srgb: texture.colorSpace === SRGBColorSpace,
     }
 
     // KTX2 圧縮を実行

--- a/packages/texture-compression/src/compress.ts
+++ b/packages/texture-compression/src/compress.ts
@@ -18,6 +18,7 @@ const DEFAULT_OPTIONS: Required<Ktx2CompressionOptions> = {
   compressionLevel: 3,
   generateMipmaps: true,
   supercompression: true,
+  srgb: false,
 }
 
 /** 出力バッファの最大サイズ（24MB） */
@@ -126,8 +127,15 @@ async function encodeWithBasis(
     // 圧縮レベル
     encoder.setCompressionLevel(options.compressionLevel)
 
-    // ミップマップ生成
+    // sRGB設定: カラーテクスチャではKTX2のDFD transferFunctionをsRGBにする。
+    // これが無いとKTX2がリニア扱いになり、BC7/ASTC等へのトランスコード後に
+    // sRGB変換が二重適用されて表示が白く浮く
+    encoder.setPerceptual(options.srgb)
+    encoder.setKTX2SRGBTransferFunc(options.srgb)
+
+    // ミップマップ生成（sRGB入力ではリニア空間でフィルタリング）
     encoder.setMipGen(options.generateMipmaps)
+    encoder.setMipSRGB(options.srgb)
 
     // ソース画像を設定（RGBA32生データ）
     const success = encoder.setSliceSourceImage(

--- a/packages/texture-compression/src/types.ts
+++ b/packages/texture-compression/src/types.ts
@@ -26,6 +26,16 @@ export interface Ktx2CompressionOptions {
   generateMipmaps?: boolean
   /** Zstandard超圧縮を使用 (デフォルト: true) */
   supercompression?: boolean
+  /**
+   * 入力がsRGBカラーデータかどうか (デフォルト: false)
+   *
+   * trueの場合、KTX2のDFD transferFunctionをsRGBとして書き出し、
+   * 知覚品質メトリクスとsRGB対応ミップマップ生成を有効化する。
+   * ベースカラー等のカラーテクスチャではtrue必須。falseのままだと
+   * KTX2がリニア扱いになり、GPU圧縮形式（BC7/ASTC等）へのトランス
+   * コード後にsRGB変換が二重適用されて色が白く浮く
+   */
+  srgb?: boolean
 }
 
 /** KTX2圧縮結果 */
@@ -87,6 +97,12 @@ export interface BasisEncoder {
   setCompressionLevel(level: number): void
   /** ミップマップ生成を設定 */
   setMipGen(generate: boolean): void
+  /** 知覚品質メトリクス（sRGB空間での誤差評価）を設定 */
+  setPerceptual(perceptual: boolean): void
+  /** KTX2のDFD transferFunctionをsRGBにするかを設定 */
+  setKTX2SRGBTransferFunc(srgb: boolean): void
+  /** sRGB対応ミップマップ生成（リニア空間でのフィルタリング）を設定 */
+  setMipSRGB(srgb: boolean): void
   /** エンコードを実行 */
   encode(outputBuffer: Uint8Array): number
   /** リソースを解放 */

--- a/packages/texture-compression/tests/compress.test.ts
+++ b/packages/texture-compression/tests/compress.test.ts
@@ -176,6 +176,46 @@ describe('texture-compression', () => {
       }
     })
 
+    it('srgb:trueでKTX2のDFD transferFunctionがsRGBになる', async () => {
+      const width = 4
+      const height = 4
+      const imageData = new Uint8Array(width * height * 4).fill(200)
+
+      const KHR_DF_TRANSFER_LINEAR = 1
+      const KHR_DF_TRANSFER_SRGB = 2
+
+      /** KTX2ヘッダのdfdByteOffsetからtransferFunctionバイトを読む */
+      const readTransferFunction = (ktx2: Uint8Array): number => {
+        const dv = new DataView(ktx2.buffer, ktx2.byteOffset, ktx2.byteLength)
+        const dfdByteOffset = dv.getUint32(48, true)
+        // DFD: totalSize(4) + vendorId/descriptorType(4) + version/blockSize(4)
+        //      + colorModel(1) + colorPrimaries(1) + transferFunction(1)
+        return ktx2[dfdByteOffset + 14]
+      }
+
+      const srgbResult = await compressToKtx2(imageData, width, height, {
+        quality: UastcQuality.Fastest,
+        srgb: true,
+      })
+      const linearResult = await compressToKtx2(imageData, width, height, {
+        quality: UastcQuality.Fastest,
+        srgb: false,
+      })
+
+      expect(srgbResult.isOk()).toBe(true)
+      expect(linearResult.isOk()).toBe(true)
+      if (srgbResult.isOk() && linearResult.isOk()) {
+        // sRGB指定＝カラーテクスチャ。リニア扱いだとトランスコード後に
+        // sRGB変換が二重適用されて表示が白く浮く（回帰確認）
+        expect(readTransferFunction(srgbResult.value.data)).toBe(
+          KHR_DF_TRANSFER_SRGB,
+        )
+        expect(readTransferFunction(linearResult.value.data)).toBe(
+          KHR_DF_TRANSFER_LINEAR,
+        )
+      }
+    })
+
     it('supercompressionを有効にすると圧縮率が上がる', async () => {
       const width = 64
       const height = 64


### PR DESCRIPTION
## 症状

このライブラリでKTX2圧縮したアバターをXRiftで表示すると、テクスチャの色が全体的に白く浮きます（彩度・明度が飛ぶ）。

| 期待 | 実機（XRift） |
|---|---|
| 彩度のある本来の色 | 全身が白っぽく浮く |

## 原因

`texture-compression` の `encodeWithBasis` が BasisEncoder に **sRGB関連の指定を行っていない**ため、生成されるKTX2の DFD `transferFunction` が常に `KHR_DF_TRANSFER_LINEAR (1)` になります。

ベースカラー等のsRGBデータを持つテクスチャがリニアとしてタグ付けされると、`KTX2Loader` はBC7/ASTC等の **sRGBでないGPU圧縮形式**にトランスコードします。その結果、sRGBエンコード済みのピクセル値がリニア値として扱われ、表示時にsRGB変換が二重適用されて白く浮きます。

実際に本ライブラリで書き出したVRM内のKTX2をパースして確認したところ、全テクスチャが `transferFunction=1 (LINEAR)` でした。

なお、**ソフトウェアGPU環境（headless Chromium等）では発症しません**。GPU圧縮形式がサポートされず非圧縮RGBAへのフォールバック経路に入り、そこでは `texture.colorSpace` の後付け指定が効くためです。開発中に気づきにくいのはこのためだと思います。

## 修正内容

- `Ktx2CompressionOptions` に `srgb` オプションを追加（デフォルト `false` ＝従来挙動のまま。法線マップ等のリニアデータに影響なし）
- `srgb: true` のとき `setPerceptual(true)` / `setKTX2SRGBTransferFunc(true)` / `setMipSRGB(true)` を設定（いずれも同梱の basis_encoder.wasm が公開済みのAPI）
- `MToonAtlasExporterPlugin` は `texture.colorSpace === SRGBColorSpace` から自動判定して `srgb` を渡す（カラーアトラスはsRGB、パラメータテクスチャはリニアのまま）
- 回帰テスト追加: 出力KTX2の DFD `transferFunction` バイトを直接検証（sRGB指定→2、未指定→1）

## 検証

- `@webxr-jp/texture-compression`: vitest 9/9 passed（新規テスト含む）
- `@webxr-jp/mtoon-atlas`: vitest 15/15 passed
- `pnpm build`（CI相当・全パッケージ）: エラーなし
- 手元でVRM（4096²ベースカラー）を `loadVRM → optimizeModel → exportVRM({textureCompression}) → loadVRM` で往復し、出力KTX2の transferFunction が SRGB(2) になることを確認

## 補足

既にこのパイプラインでアップロード済みのアバターはKTX2がリニアタグのままなので、サーバ側で再処理するか再アップロードが必要になると思います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhNpKCBs1osX2ktPVgSNtW
