### PR TITLE
fix: pnpm の allowBuilds を明示して npm publish の失敗を解消

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,15 @@ packages:
   - 'packages/texture-compression'
   - 'packages/debug-viewer'
   - 'packages/mtoon-atlas'
+# 依存パッケージの build scripts を実行するかの明示的な許可リスト。
+# 未指定のまま放置すると pnpm install が ERR_PNPM_IGNORED_BUILDS (exit 1) になり、
+# npm publish の prepublishOnly → pnpm run 内の依存チェックが失敗して
+# release ワークフローの publish が落ちる。
+# 全パッケージとも build scripts なしで動作実績があるため false（従来挙動の明文化）。
+allowBuilds:
+  '@swc/core': false
+  canvas: false
+  edgedriver: false
+  esbuild: false
+  geckodriver: false
+  msw: false


### PR DESCRIPTION
## 症状

Release PR #38 マージ後の publish で `@webxr-jp/avatar-optimizer@0.1.6` のみ公開に失敗しました（`@webxr-jp/mtoon-atlas@0.1.5` / `@webxr-jp/texture-compression@0.1.1` は公開成功）。

```
🦋  error an error occurred while publishing @webxr-jp/avatar-optimizer: ELIFECYCLE undefined
🦋  error npm notice run pnpm lint:fix && pnpm typecheck && tsup
```

7/13 の release run（#35 マージ後）も同じパターンで failure になっており、再発性のある問題です。

## 原因

ローカルの `npm publish --dry-run` で完全再現できました。連鎖は以下のとおりです:

1. avatar-optimizer だけが `prepublishOnly: npm run build` を持つ（他 2 パッケージにはない → 成功/失敗の差の理由）
2. build script の `pnpm lint:fix` 実行時、pnpm 11 の run 前依存チェック（verify-deps-before-run）が `pnpm install` を自動実行する
3. 依存の build scripts 許可が未指定のため、その install が `ERR_PNPM_IGNORED_BUILDS` で **exit 1** になる
4. prepublishOnly が失敗し、changesets からは `ELIFECYCLE undefined` としか見えない

## 修正

`pnpm-workspace.yaml` に `allowBuilds` を明示（pnpm が要求しているのは true/false の明示的な決定）。全パッケージとも build scripts を実行しない状態で動作実績があるため、**従来挙動の明文化として全件 false** を設定しました。挙動の変更はありません。

## 検証

- `pnpm install` が exit 0 になること
- `packages/avatar-optimizer` で `npm publish --dry-run` が prepublishOnly（lint / typecheck / tsup）込みで成功し、`+ @webxr-jp/avatar-optimizer@0.1.6` まで到達すること

## マージ後の対応

avatar-optimizer@0.1.6 が未公開のまま残っているため、マージ後に main の release ワークフローが再実行されれば changesets が未公開バージョンを検出して publish します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)