### PR TITLE
fix: COLOR_0頂点カラーを持つアバターが最適化後に不可視になる問題を修正

### DIFF
--- a/.changeset/mtoon-atlas-ignore-vertex-color.md
+++ b/.changeset/mtoon-atlas-ignore-vertex-color.md
@@ -1,0 +1,5 @@
+---
+'@webxr-jp/mtoon-atlas': patch
+---
+
+COLOR_0頂点カラーを持つVRMを最適化すると、再読込時にシェーダーがコンパイルエラーになりアバターが不可視になる問題を修正。MToonAtlasMaterialに、上流three-vrmのMToonMaterialが既定で設定しているのと同じ`IGNORE_VERTEX_COLOR` defineを追加する（VRM0.x MToonの「頂点カラーを無視する」意味論とも一致）

--- a/packages/avatar-optimizer/tests/browser/MToonAtlasRoundtrip.test.ts
+++ b/packages/avatar-optimizer/tests/browser/MToonAtlasRoundtrip.test.ts
@@ -1,15 +1,12 @@
-import { VRM, VRMLoaderPlugin } from '@pixiv/three-vrm'
-import {
-  MToonAtlasExporterPlugin,
-  MToonAtlasLoaderPlugin,
-  MToonAtlasMaterial,
-} from '@webxr-jp/mtoon-atlas'
-import { Object3D, Scene, SkinnedMesh, SRGBColorSpace, Texture } from 'three'
-import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js'
-import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { VRM } from '@pixiv/three-vrm'
+import { MToonAtlasMaterial } from '@webxr-jp/mtoon-atlas'
+import { Object3D, SkinnedMesh, SRGBColorSpace, Texture } from 'three'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { optimizeModel } from '../../src/avatar-optimizer'
-import { VRMExporterPlugin } from '../../src/exporter/VRMExporterPlugin'
+import {
+  exportVRMToBuffer,
+  loadVRMFromBuffer,
+} from './helpers/vrm-roundtrip'
 
 /**
  * MToonAtlasMaterialを使用した最適化済みVRMのラウンドトリップテスト
@@ -23,62 +20,6 @@ describe('MToonAtlas Roundtrip', () => {
   let optimizedVRM: VRM
   let reloadedVRM: VRM
   let exportedBuffer: ArrayBuffer
-
-  /**
-   * VRMを読み込むヘルパー関数
-   */
-  async function loadVRM(
-    buffer: ArrayBuffer,
-  ): Promise<{ gltf: GLTF; vrm: VRM }> {
-    const loader = new GLTFLoader()
-    loader.register((parser) => new VRMLoaderPlugin(parser))
-    loader.register((parser) => new MToonAtlasLoaderPlugin(parser))
-
-    const gltf = await loader.parseAsync(buffer, '')
-    const vrm = gltf.userData.vrm as VRM
-
-    return { gltf, vrm }
-  }
-
-  /**
-   * VRMをGLBとしてエクスポートするヘルパー関数
-   */
-  async function exportVRM(vrm: VRM): Promise<ArrayBuffer> {
-    const exporter = new GLTFExporter()
-    exporter.register((writer) => {
-      const plugin = new VRMExporterPlugin(writer)
-      plugin.setVRM(vrm)
-      return plugin
-    })
-    exporter.register((writer) => new MToonAtlasExporterPlugin(writer))
-
-    return new Promise<ArrayBuffer>((resolve, reject) => {
-      const exportScene = new Scene()
-      const children = [...vrm.scene.children].filter(
-        (child) =>
-          child.name !== 'VRMHumanoidRig' &&
-          !child.name.startsWith('VRMExpression'),
-      )
-      children.forEach((child) => exportScene.add(child))
-
-      exporter.parse(
-        exportScene,
-        (result) => {
-          children.forEach((child) => vrm.scene.add(child))
-          if (result instanceof ArrayBuffer) {
-            resolve(result)
-          } else {
-            reject(new Error('Expected ArrayBuffer output'))
-          }
-        },
-        (error) => {
-          children.forEach((child) => vrm.scene.add(child))
-          reject(error)
-        },
-        { binary: true },
-      )
-    })
-  }
 
   /**
    * テクスチャからピクセルデータを取得するヘルパー関数
@@ -156,14 +97,14 @@ describe('MToonAtlas Roundtrip', () => {
   beforeAll(async () => {
     const response = await fetch(VRM_FILE_PATH)
     const originalBuffer = await response.arrayBuffer()
-    const { vrm } = await loadVRM(originalBuffer)
+    const { vrm } = await loadVRMFromBuffer(originalBuffer)
 
     const optimizeResult = await optimizeModel(vrm)
     expect(optimizeResult.isOk()).toBe(true)
     optimizedVRM = vrm
 
-    exportedBuffer = await exportVRM(optimizedVRM)
-    const { vrm: reloaded } = await loadVRM(exportedBuffer)
+    exportedBuffer = await exportVRMToBuffer(optimizedVRM)
+    const { vrm: reloaded } = await loadVRMFromBuffer(exportedBuffer)
     reloadedVRM = reloaded
   })
 

--- a/packages/avatar-optimizer/tests/browser/VertexColorRoundtrip.test.ts
+++ b/packages/avatar-optimizer/tests/browser/VertexColorRoundtrip.test.ts
@@ -1,9 +1,5 @@
-import { VRM, VRMLoaderPlugin } from '@pixiv/three-vrm'
-import {
-  MToonAtlasExporterPlugin,
-  MToonAtlasLoaderPlugin,
-  MToonAtlasMaterial,
-} from '@webxr-jp/mtoon-atlas'
+import { VRM } from '@pixiv/three-vrm'
+import { MToonAtlasMaterial } from '@webxr-jp/mtoon-atlas'
 import {
   AmbientLight,
   BufferAttribute,
@@ -15,11 +11,12 @@ import {
   WebGLRenderer,
   WebGLRenderTarget,
 } from 'three'
-import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js'
-import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { optimizeModel } from '../../src/avatar-optimizer'
-import { VRMExporterPlugin } from '../../src/exporter/VRMExporterPlugin'
+import {
+  exportVRMToBuffer,
+  loadVRMFromBuffer,
+} from './helpers/vrm-roundtrip'
 
 /**
  * COLOR_0頂点カラーを持つVRMのラウンドトリップ回帰テスト
@@ -42,56 +39,9 @@ describe('VertexColor Roundtrip', () => {
   const RENDER_SIZE = 256
 
   let reloadedVRM: VRM
-
-  async function loadVRM(
-    buffer: ArrayBuffer,
-  ): Promise<{ gltf: GLTF; vrm: VRM }> {
-    const loader = new GLTFLoader()
-    loader.register((parser) => new VRMLoaderPlugin(parser))
-    loader.register((parser) => new MToonAtlasLoaderPlugin(parser))
-
-    const gltf = await loader.parseAsync(buffer, '')
-    const vrm = gltf.userData.vrm as VRM
-
-    return { gltf, vrm }
-  }
-
-  async function exportVRM(vrm: VRM): Promise<ArrayBuffer> {
-    const exporter = new GLTFExporter()
-    exporter.register((writer) => {
-      const plugin = new VRMExporterPlugin(writer)
-      plugin.setVRM(vrm)
-      return plugin
-    })
-    exporter.register((writer) => new MToonAtlasExporterPlugin(writer))
-
-    return new Promise<ArrayBuffer>((resolve, reject) => {
-      const exportScene = new Scene()
-      const children = [...vrm.scene.children].filter(
-        (child) =>
-          child.name !== 'VRMHumanoidRig' &&
-          !child.name.startsWith('VRMExpression'),
-      )
-      children.forEach((child) => exportScene.add(child))
-
-      exporter.parse(
-        exportScene,
-        (result) => {
-          children.forEach((child) => vrm.scene.add(child))
-          if (result instanceof ArrayBuffer) {
-            resolve(result)
-          } else {
-            reject(new Error('Expected ArrayBuffer output'))
-          }
-        },
-        (error) => {
-          children.forEach((child) => vrm.scene.add(child))
-          reject(error)
-        },
-        { binary: true },
-      )
-    })
-  }
+  // レンダリングは SwiftShader 上で重く、WebGL コンテキストも消費するため
+  // beforeAll で1回だけ実行して結果を使い回す
+  let renderResult: { brokenProgramCount: number; pixelCoverage: number }
 
   /**
    * 全メッシュにCOLOR_0(VEC4, 全成分1.0)を注入する
@@ -159,16 +109,21 @@ describe('VertexColor Roundtrip', () => {
       if (pixels[i] > 0) covered++
     }
 
-    // WebGLProgram.diagnostics はコンパイル/リンク失敗時のみ設定される
+    // diagnostics はリンク成功時にも設定されうる（info log が空でなければ
+    // warn 経路でも生成され runnable: true になる）ため、
+    // 存在の有無ではなく runnable を見る。
+    // そうしないとコンパイラの警告だけで壊れた扱いになってしまう
     const programs = renderer.info.programs ?? []
     const brokenProgramCount = programs.filter(
       (program) =>
-        (program as unknown as { diagnostics?: unknown }).diagnostics !==
-        undefined,
+        (program as unknown as { diagnostics?: { runnable?: boolean } })
+          .diagnostics?.runnable === false,
     ).length
 
     scene.remove(vrm.scene)
     target.dispose()
+    // dispose だけでは WebGL コンテキストが残るため明示的に解放する
+    renderer.forceContextLoss()
     renderer.dispose()
 
     return {
@@ -180,7 +135,7 @@ describe('VertexColor Roundtrip', () => {
   beforeAll(async () => {
     const response = await fetch(VRM_FILE_PATH)
     const originalBuffer = await response.arrayBuffer()
-    const { vrm } = await loadVRM(originalBuffer)
+    const { vrm } = await loadVRMFromBuffer(originalBuffer)
 
     const injected = injectVertexColors(vrm)
     expect(injected).toBeGreaterThan(0)
@@ -188,9 +143,10 @@ describe('VertexColor Roundtrip', () => {
     const optimizeResult = await optimizeModel(vrm)
     expect(optimizeResult.isOk()).toBe(true)
 
-    const exportedBuffer = await exportVRM(vrm)
-    const { vrm: reloaded } = await loadVRM(exportedBuffer)
+    const exportedBuffer = await exportVRMToBuffer(vrm)
+    const { vrm: reloaded } = await loadVRMFromBuffer(exportedBuffer)
     reloadedVRM = reloaded
+    renderResult = renderAndInspect(reloadedVRM)
   })
 
   it('should keep COLOR_0 through the roundtrip (test premise)', () => {
@@ -207,14 +163,12 @@ describe('VertexColor Roundtrip', () => {
   })
 
   it('should compile all shader programs after reload', () => {
-    const { brokenProgramCount } = renderAndInspect(reloadedVRM)
-    expect(brokenProgramCount).toBe(0)
+    expect(renderResult.brokenProgramCount).toBe(0)
   })
 
   it('should actually draw the avatar (not invisible)', () => {
-    const { pixelCoverage } = renderAndInspect(reloadedVRM)
     // シェーダーが壊れているとメッシュが1ピクセルも描かれず0になる
-    expect(pixelCoverage).toBeGreaterThan(0.01)
+    expect(renderResult.pixelCoverage).toBeGreaterThan(0.01)
   })
 
   it('should define IGNORE_VERTEX_COLOR on reloaded atlas materials', () => {

--- a/packages/avatar-optimizer/tests/browser/VertexColorRoundtrip.test.ts
+++ b/packages/avatar-optimizer/tests/browser/VertexColorRoundtrip.test.ts
@@ -1,0 +1,239 @@
+import { VRM, VRMLoaderPlugin } from '@pixiv/three-vrm'
+import {
+  MToonAtlasExporterPlugin,
+  MToonAtlasLoaderPlugin,
+  MToonAtlasMaterial,
+} from '@webxr-jp/mtoon-atlas'
+import {
+  AmbientLight,
+  BufferAttribute,
+  DirectionalLight,
+  Mesh,
+  PerspectiveCamera,
+  Scene,
+  SkinnedMesh,
+  WebGLRenderer,
+  WebGLRenderTarget,
+} from 'three'
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js'
+import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { optimizeModel } from '../../src/avatar-optimizer'
+import { VRMExporterPlugin } from '../../src/exporter/VRMExporterPlugin'
+
+/**
+ * COLOR_0頂点カラーを持つVRMのラウンドトリップ回帰テスト
+ *
+ * ジオメトリにCOLOR_0(VEC4)を持つVRMを最適化・エクスポートすると、
+ * 再読込時にGLTFLoaderが `vertexColors = true` を設定し、VEC4のため
+ * three.jsが `USE_COLOR_ALPHA` を注入して `vColor` がvec4になる。
+ * MToonAtlasMaterialに `IGNORE_VERTEX_COLOR` defineが無いと
+ * mtoon.fragの `diffuseColor.rgb *= vColor` / `material.shadeColor.rgb *= vColor`
+ * が vec3 *= vec4 のGLSLコンパイルエラーとなり、メッシュが一切
+ * 描画されない（アバターが不可視になる）。
+ *
+ * VRoid/UniVRM系の書き出しは通常COLOR_0を含まないが、Blender等の
+ * 汎用DCCツール経由のVRMは頂点カラーを保持していることがある。
+ * COLOR_0はglTF 2.0の正規属性であり、上流three-vrmのMToonMaterialは
+ * `ignoreVertexColor = true` を既定にしてこのケースを吸収している。
+ */
+describe('VertexColor Roundtrip', () => {
+  const VRM_FILE_PATH = '/AliciaSolid.vrm'
+  const RENDER_SIZE = 256
+
+  let reloadedVRM: VRM
+
+  async function loadVRM(
+    buffer: ArrayBuffer,
+  ): Promise<{ gltf: GLTF; vrm: VRM }> {
+    const loader = new GLTFLoader()
+    loader.register((parser) => new VRMLoaderPlugin(parser))
+    loader.register((parser) => new MToonAtlasLoaderPlugin(parser))
+
+    const gltf = await loader.parseAsync(buffer, '')
+    const vrm = gltf.userData.vrm as VRM
+
+    return { gltf, vrm }
+  }
+
+  async function exportVRM(vrm: VRM): Promise<ArrayBuffer> {
+    const exporter = new GLTFExporter()
+    exporter.register((writer) => {
+      const plugin = new VRMExporterPlugin(writer)
+      plugin.setVRM(vrm)
+      return plugin
+    })
+    exporter.register((writer) => new MToonAtlasExporterPlugin(writer))
+
+    return new Promise<ArrayBuffer>((resolve, reject) => {
+      const exportScene = new Scene()
+      const children = [...vrm.scene.children].filter(
+        (child) =>
+          child.name !== 'VRMHumanoidRig' &&
+          !child.name.startsWith('VRMExpression'),
+      )
+      children.forEach((child) => exportScene.add(child))
+
+      exporter.parse(
+        exportScene,
+        (result) => {
+          children.forEach((child) => vrm.scene.add(child))
+          if (result instanceof ArrayBuffer) {
+            resolve(result)
+          } else {
+            reject(new Error('Expected ArrayBuffer output'))
+          }
+        },
+        (error) => {
+          children.forEach((child) => vrm.scene.add(child))
+          reject(error)
+        },
+        { binary: true },
+      )
+    })
+  }
+
+  /**
+   * 全メッシュにCOLOR_0(VEC4, 全成分1.0)を注入する
+   * 全て1.0=純白なので、頂点カラーが正しく無視されても乗算されても
+   * 見た目は変わらない（コンパイル可否だけが差になる）
+   */
+  function injectVertexColors(vrm: VRM): number {
+    let injected = 0
+    vrm.scene.traverse((object) => {
+      if (object instanceof Mesh) {
+        const geometry = object.geometry
+        const position = geometry.getAttribute('position')
+        if (!position) return
+        const colors = new Float32Array(position.count * 4).fill(1)
+        geometry.setAttribute('color', new BufferAttribute(colors, 4))
+        injected++
+      }
+    })
+    return injected
+  }
+
+  /**
+   * 実際にレンダリングして、シェーダーコンパイル診断と
+   * 描画ピクセル被覆率（アバターが見えているか）を測る
+   */
+  function renderAndInspect(vrm: VRM): {
+    brokenProgramCount: number
+    pixelCoverage: number
+  } {
+    const canvas = document.createElement('canvas')
+    canvas.width = RENDER_SIZE
+    canvas.height = RENDER_SIZE
+    const renderer = new WebGLRenderer({ canvas, alpha: true })
+    renderer.setClearAlpha(0)
+
+    const scene = new Scene()
+    scene.add(new AmbientLight(0xffffff, 1))
+    const light = new DirectionalLight(0xffffff, 2)
+    light.position.set(1, 1, 1)
+    scene.add(light)
+    scene.add(vrm.scene)
+    vrm.scene.traverse((object) => {
+      object.frustumCulled = false
+    })
+
+    const camera = new PerspectiveCamera(50, 1, 0.1, 100)
+    camera.position.set(0, 1, 3)
+    camera.lookAt(0, 1, 0)
+
+    const target = new WebGLRenderTarget(RENDER_SIZE, RENDER_SIZE)
+    renderer.setRenderTarget(target)
+    renderer.render(scene, camera)
+
+    const pixels = new Uint8Array(RENDER_SIZE * RENDER_SIZE * 4)
+    renderer.readRenderTargetPixels(
+      target,
+      0,
+      0,
+      RENDER_SIZE,
+      RENDER_SIZE,
+      pixels,
+    )
+    let covered = 0
+    for (let i = 3; i < pixels.length; i += 4) {
+      if (pixels[i] > 0) covered++
+    }
+
+    // WebGLProgram.diagnostics はコンパイル/リンク失敗時のみ設定される
+    const programs = renderer.info.programs ?? []
+    const brokenProgramCount = programs.filter(
+      (program) =>
+        (program as unknown as { diagnostics?: unknown }).diagnostics !==
+        undefined,
+    ).length
+
+    scene.remove(vrm.scene)
+    target.dispose()
+    renderer.dispose()
+
+    return {
+      brokenProgramCount,
+      pixelCoverage: covered / (RENDER_SIZE * RENDER_SIZE),
+    }
+  }
+
+  beforeAll(async () => {
+    const response = await fetch(VRM_FILE_PATH)
+    const originalBuffer = await response.arrayBuffer()
+    const { vrm } = await loadVRM(originalBuffer)
+
+    const injected = injectVertexColors(vrm)
+    expect(injected).toBeGreaterThan(0)
+
+    const optimizeResult = await optimizeModel(vrm)
+    expect(optimizeResult.isOk()).toBe(true)
+
+    const exportedBuffer = await exportVRM(vrm)
+    const { vrm: reloaded } = await loadVRM(exportedBuffer)
+    reloadedVRM = reloaded
+  })
+
+  it('should keep COLOR_0 through the roundtrip (test premise)', () => {
+    // COLOR_0がエクスポートで消えるとこのテストはトリガーを失う。
+    // その場合はここが落ちて、テストの前提が壊れたことを知らせる
+    let found = 0
+    reloadedVRM.scene.traverse((object) => {
+      if (object instanceof SkinnedMesh) {
+        const color = object.geometry.getAttribute('color')
+        if (color && color.itemSize === 4) found++
+      }
+    })
+    expect(found).toBeGreaterThan(0)
+  })
+
+  it('should compile all shader programs after reload', () => {
+    const { brokenProgramCount } = renderAndInspect(reloadedVRM)
+    expect(brokenProgramCount).toBe(0)
+  })
+
+  it('should actually draw the avatar (not invisible)', () => {
+    const { pixelCoverage } = renderAndInspect(reloadedVRM)
+    // シェーダーが壊れているとメッシュが1ピクセルも描かれず0になる
+    expect(pixelCoverage).toBeGreaterThan(0.01)
+  })
+
+  it('should define IGNORE_VERTEX_COLOR on reloaded atlas materials', () => {
+    const materials: MToonAtlasMaterial[] = []
+    reloadedVRM.scene.traverse((object) => {
+      if (object instanceof SkinnedMesh) {
+        const meshMaterials = Array.isArray(object.material)
+          ? object.material
+          : [object.material]
+        for (const material of meshMaterials) {
+          if (material && 'isMToonAtlasMaterial' in material) {
+            materials.push(material as MToonAtlasMaterial)
+          }
+        }
+      }
+    })
+    expect(materials.length).toBeGreaterThan(0)
+    for (const material of materials) {
+      expect(material.defines).toHaveProperty('IGNORE_VERTEX_COLOR')
+    }
+  })
+})

--- a/packages/avatar-optimizer/tests/browser/helpers/vrm-roundtrip.ts
+++ b/packages/avatar-optimizer/tests/browser/helpers/vrm-roundtrip.ts
@@ -1,0 +1,81 @@
+/**
+ * ブラウザテスト共通の VRM ラウンドトリップヘルパー
+ *
+ * 読み込み・エクスポートの手順（プラグインの登録順、エクスポート対象から
+ * VRMHumanoidRig / VRMExpression を外して終了後に戻す扱い）は
+ * ラウンドトリップ系テストで共通なので、ここに集約する。
+ */
+import { VRM, VRMLoaderPlugin } from '@pixiv/three-vrm'
+import {
+  MToonAtlasExporterPlugin,
+  MToonAtlasLoaderPlugin,
+} from '@webxr-jp/mtoon-atlas'
+import { Scene } from 'three'
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js'
+import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { VRMExporterPlugin } from '../../../src/exporter/VRMExporterPlugin'
+
+/**
+ * GLB バイナリから VRM を読み込む
+ *
+ * @param buffer - GLB バイナリ
+ * @returns 読み込んだ gltf と VRM
+ */
+export async function loadVRMFromBuffer(
+  buffer: ArrayBuffer,
+): Promise<{ gltf: GLTF; vrm: VRM }> {
+  const loader = new GLTFLoader()
+  loader.register((parser) => new VRMLoaderPlugin(parser))
+  loader.register((parser) => new MToonAtlasLoaderPlugin(parser))
+
+  const gltf = await loader.parseAsync(buffer, '')
+  const vrm = gltf.userData.vrm as VRM
+
+  return { gltf, vrm }
+}
+
+/**
+ * VRM を GLB としてエクスポートする
+ *
+ * VRMHumanoidRig と VRMExpression* はエクスポート対象から外し、
+ * 成否によらず元の vrm.scene に戻す。
+ *
+ * @param vrm - エクスポートする VRM
+ * @returns GLB バイナリ
+ */
+export async function exportVRMToBuffer(vrm: VRM): Promise<ArrayBuffer> {
+  const exporter = new GLTFExporter()
+  exporter.register((writer) => {
+    const plugin = new VRMExporterPlugin(writer)
+    plugin.setVRM(vrm)
+    return plugin
+  })
+  exporter.register((writer) => new MToonAtlasExporterPlugin(writer))
+
+  return new Promise<ArrayBuffer>((resolve, reject) => {
+    const exportScene = new Scene()
+    const children = [...vrm.scene.children].filter(
+      (child) =>
+        child.name !== 'VRMHumanoidRig' &&
+        !child.name.startsWith('VRMExpression'),
+    )
+    children.forEach((child) => exportScene.add(child))
+
+    exporter.parse(
+      exportScene,
+      (result) => {
+        children.forEach((child) => vrm.scene.add(child))
+        if (result instanceof ArrayBuffer) {
+          resolve(result)
+        } else {
+          reject(new Error('Expected ArrayBuffer output'))
+        }
+      },
+      (error) => {
+        children.forEach((child) => vrm.scene.add(child))
+        reject(error)
+      },
+      { binary: true },
+    )
+  })
+}

--- a/packages/mtoon-atlas/src/MToonAtlasMaterial.ts
+++ b/packages/mtoon-atlas/src/MToonAtlasMaterial.ts
@@ -142,6 +142,10 @@ export class MToonAtlasMaterial extends THREE.ShaderMaterial
       clipping: true,
       defines: {
         THREE_VRM_THREE_REVISION: parseInt(THREE.REVISION).toString(),
+        // 上流three-vrmのMToonMaterialはignoreVertexColor=trueが既定。
+        // このdefineが無いとCOLOR_0(VEC4)を持つモデルでUSE_COLOR_ALPHAが立ち、
+        // `diffuseColor.rgb *= vColor`(vec3 *= vec4)がコンパイル不能になる
+        IGNORE_VERTEX_COLOR: '',
       },
     })
 

--- a/packages/mtoon-atlas/tests/mtoon-atlas.test.ts
+++ b/packages/mtoon-atlas/tests/mtoon-atlas.test.ts
@@ -14,5 +14,19 @@ describe('MToonAtlasMaterial', () => {
     expect(material.isMToonAtlasMaterial).toBe(true)
   })
 
+  it('should define IGNORE_VERTEX_COLOR by default (upstream three-vrm parity)', () => {
+    // 上流three-vrmのMToonMaterialは ignoreVertexColor=true が既定。
+    // このdefineが無いと、COLOR_0(VEC4)を持つジオメトリで
+    // USE_COLOR_ALPHA が注入され、mtoon.frag の
+    // `diffuseColor.rgb *= vColor` が vec3 *= vec4 のコンパイルエラーになる
+    const material = new MToonAtlasMaterial()
+    expect(material.defines).toHaveProperty('IGNORE_VERTEX_COLOR')
+  })
+
+  it('should guard vertex color usage with IGNORE_VERTEX_COLOR in shaders', () => {
+    const material = new MToonAtlasMaterial()
+    expect(material.fragmentShader).toContain('IGNORE_VERTEX_COLOR')
+  })
+
   // TODO: 詳細なテストケースを追加
 })


### PR DESCRIPTION
## 症状

ジオメトリに `COLOR_0`（頂点カラー）を持つVRMをアップロード最適化（`optimizeModel` → `exportVRM`）すると、**再読込時にMToonAtlasMaterialのシェーダーがコンパイルエラーになり、メッシュが一切描画されなくなります**（アバターが不可視になる。影だけは深度マテリアル経由で描かれます）。

```
ERROR: 'assign' : cannot convert from 'in highp 4-component vector of float' to 'highp 3-component vector of float'  ×2
THREE.WebGLProgram: Shader Error 0 - VALIDATE_STATUS false
WebGL: INVALID_OPERATION: useProgram: program not valid  （毎フレーム）
```

## 再現

公式サンプル AliciaSolid.vrm の全ジオメトリに `COLOR_0`（VEC4・全成分1.0＝純白）を注入 → `optimizeModel` → エクスポート → 再読込 → レンダリング、で100%再現します（今回追加した `VertexColorRoundtrip.test.ts` がこの手順そのものです）。

値が全て1.0でも壊れるため、**頂点カラーの値は無関係で、「VEC4のCOLOR_0が存在すること」だけがトリガー**です。

## 真因

`mtoon.frag` / `mtoon.vert` は上流 three-vrm の MToon シェーダー由来で、頂点カラー乗算を次のガード付きで持っています（410行・624行）:

```glsl
#if ( defined( USE_COLOR ) && !defined( IGNORE_VERTEX_COLOR ) )
  diffuseColor.rgb *= vColor;
#endif
```

上流の `MToonMaterial` は `ignoreVertexColor = true` を既定とし、defines に `IGNORE_VERTEX_COLOR` を注入しますが（[three-vrmのMToonMaterial実装](https://github.com/pixiv/three-vrm/blob/dev/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts)）、**MToonAtlasMaterial にはこの配線がありません**。

そのため:

1. 最適化済みVRMのジオメトリに `COLOR_0` が残る（マージ・エクスポートは属性を保持する）
2. 再読込時に GLTFLoader が `vertexColors = true` を設定
3. `COLOR_0` が VEC4 なので three.js が `USE_COLOR_ALPHA` を注入 → `vColor` が **vec4** になる
4. `diffuseColor.rgb *= vColor` と `material.shadeColor.rgb *= vColor` が **vec3 *= vec4** でGLSLコンパイル不能 → program not valid → 描画されない

## 修正

上流と同じく、defines に `IGNORE_VERTEX_COLOR` を既定で設定します（4行）。頂点カラーを無視する挙動は VRM0.x MToon の意味論（頂点カラー非対応）とも一致し、最適化前後で見た目が変わりません。

## テスト

- **mtoon-atlas 単体テスト**: `defines` に `IGNORE_VERTEX_COLOR` が含まれること／シェーダーにガードが存在すること
- **avatar-optimizer ブラウザ回帰テスト**（`VertexColorRoundtrip.test.ts`）: COLOR_0注入 → 最適化 → エクスポート → 再読込 → 実レンダリングし、①全シェーダープログラムがコンパイル可能（`WebGLProgram.diagnostics` 不在）②アバターが実際に描画される（レンダーターゲットのピクセル被覆率 > 1%）③再読込後のマテリアルに define が存在、を検証。**修正なしではこの3件が失敗することを確認済み**（壊れたprogram 7個・被覆率0）
- 既存スイートは全緑: mtoon-atlas 17/17・avatar-optimizer 140/140（browser mode）

## 影響範囲

- 修正は**読込時のマテリアル生成側**なので、既にアップロード済みの `COLOR_0` 入りアバターも、クライアントのパッケージ更新だけで治ります（#36/#37 と違い再アップロード不要）
- VRoid/UniVRM系の書き出しは通常 `COLOR_0` を含まないため既存アバターではほぼ顕在化しませんが、Blender等の汎用DCC経由のVRMは頂点カラーを保持していることがあり、`COLOR_0` はglTF 2.0の正規属性です（発見の経緯はPS1実機モデルの計測VRM＝頂点カラー保持、のアップロードでした）

## 補足（スコープ外）

最適化時に `COLOR_0` を除去すればファイルサイズも削れます（MToonでは無視される属性のため）。本PRはランタイム互換の最小修正に留めたので、必要でしたら別PRで対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvHHZQtkJT6EyefM9o77Kx
