### PR TITLE
chore(debug-viewer): 3D Viewport の操作UIを左サイドバーに整理

### DIFF
--- a/packages/debug-viewer/CLAUDE.md
+++ b/packages/debug-viewer/CLAUDE.md
@@ -19,7 +19,9 @@ window.__spector.captureNextFrame(document.querySelector('canvas'))
 
 ### 利用可能なボタン
 
-デバッグパネル（右下）に以下のボタンがあります：
+左サイドバーの **「WebGL ツール」セクション** に以下のボタンがあります。
+このセクションは既定で折りたたまれているため、**先に見出しをクリックして開く**必要があります
+（折りたたみ中は DOM 上に存在しないので、クリック前にセレクタで見つかりません）。
 
 | ボタン | 機能 | 出力形式 |
 |--------|------|----------|
@@ -57,10 +59,13 @@ browser_console_messages({ level: "debug" })
 #### テクスチャ一覧取得
 
 ```typescript
-// 1. ボタンクリック
-browser_click({ element: "List Tex button", ref: "e61" })
+// 1. 「WebGL ツール」セクションを開く（既定で折りたたみ）
+browser_click({ element: "WebGL ツール section header", ref: 'button:has-text("WebGL")' })
 
-// 2. コンソールからデータ取得
+// 2. ボタンクリック
+browser_click({ element: "List Tex button", ref: 'button:has-text("List Tex")' })
+
+// 3. コンソールからデータ取得
 browser_console_messages({ level: "debug" })
 // → [WebGLDebug:TextureList] のログにJSON形式でテクスチャ情報
 ```
@@ -68,10 +73,13 @@ browser_console_messages({ level: "debug" })
 #### フレームバッファ取得
 
 ```typescript
-// 1. ボタンクリック
-browser_click({ element: "Dump FB button", ref: "e63" })
+// 1. 「WebGL ツール」セクションを開く（既定で折りたたみ）
+browser_click({ element: "WebGL ツール section header", ref: 'button:has-text("WebGL")' })
 
-// 2. コンソールからデータ取得
+// 2. ボタンクリック
+browser_click({ element: "Dump FB button", ref: 'button:has-text("Dump FB")' })
+
+// 3. コンソールからデータ取得
 browser_console_messages({ level: "debug" })
 // → [WebGLDebug:Base64] のログにdata:image/png;base64,...形式で画像データ
 ```

--- a/packages/debug-viewer/src/components/VRMCanvas.css
+++ b/packages/debug-viewer/src/components/VRMCanvas.css
@@ -1,383 +1,318 @@
-.vrm-canvas__header {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+/*
+ * VRM Debug Viewer のレイアウト
+ *
+ * 3D Viewport タブは「左サイドバー（操作系）＋ ビューポート」の 2 カラム。
+ * 操作系はすべてサイドバー内の折りたたみセクションに収め、
+ * ビューポート上に重ねるのはエラー表示とステータスバーだけにしている。
+ */
+
+:root {
+  --vrm-bg: #1e1e1e;
+  --vrm-bg-raised: #262626;
+  --vrm-border: #3a3a3a;
+  --vrm-text: #e8e8e8;
+  --vrm-text-dim: #9a9a9a;
+  --vrm-accent: #2d7ff9;
+}
+
+.vrm-canvas {
   display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem;
-  background-color: rgba(30, 30, 30, 0.95);
-  border-bottom: 1px solid #333;
-  z-index: 100;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
 }
 
-.vrm-canvas__header h1 {
-  margin: 0;
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: #fff;
+.vrm-canvas__viewport {
+  position: relative;
+  flex: 1;
+  min-width: 0;
 }
 
-.vrm-canvas__model-select {
-  padding: 0.5rem 0.75rem;
-  background-color: #2a2a2a;
-  color: #fff;
-  border: 1px solid #555;
-  border-radius: 4px;
-  font-size: 0.875rem;
-  cursor: pointer;
-}
+/* ---------------- サイドバー ---------------- */
 
-.vrm-canvas__model-select:hover:not(:disabled) {
-  border-color: #777;
-}
-
-.vrm-canvas__model-select:focus {
-  outline: none;
-  border-color: #0066cc;
-}
-
-.vrm-canvas__model-select:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.vrm-canvas__upload-btn,
-.vrm-canvas__optimize-btn,
-.vrm-canvas__export-btn,
-.vrm-canvas__export-gltf-btn {
-  padding: 0.5rem 1rem;
-  background-color: #0066cc;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 500;
-  transition: background-color 0.2s;
-}
-
-.vrm-canvas__upload-btn:hover:not(:disabled),
-.vrm-canvas__optimize-btn:hover:not(:disabled),
-.vrm-canvas__export-btn:hover:not(:disabled),
-.vrm-canvas__export-gltf-btn:hover:not(:disabled) {
-  background-color: #0052a3;
-}
-
-.vrm-canvas__upload-btn:disabled,
-.vrm-canvas__optimize-btn:disabled,
-.vrm-canvas__export-btn:disabled,
-.vrm-canvas__export-gltf-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.vrm-canvas__error {
-  position: absolute;
-  top: 60px;
-  left: 0;
-  right: 0;
-  padding: 0.75rem 1rem;
-  background-color: #c41c3b;
-  color: white;
-  font-size: 0.875rem;
-  border-bottom: 1px solid #a01530;
-  z-index: 99;
-}
-
-.vrm-canvas__info {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 0.75rem 1rem;
-  background-color: rgba(30, 30, 30, 0.95);
-  border-top: 1px solid #333;
-  font-size: 0.875rem;
-  color: #fff;
-  z-index: 100;
-}
-
-.vrm-canvas__info p {
-  margin: 0;
-}
-
-/* デバッグパネル */
-.vrm-canvas__debug-panel {
-  position: absolute;
-  bottom: 50px;
-  right: 10px;
-  padding: 0.75rem 1rem;
-  background-color: rgba(30, 30, 30, 0.95);
-  border: 1px solid #444;
-  border-radius: 6px;
+.vrm-sidebar {
+  flex: 0 0 260px;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  z-index: 100;
-  color: #fff;
-  font-size: 0.875rem;
-}
-
-.vrm-canvas__debug-panel label {
-  font-weight: 500;
-  color: #ccc;
-}
-
-.vrm-canvas__debug-select {
-  padding: 0.4rem 0.6rem;
-  background-color: #2a2a2a;
-  color: #fff;
-  border: 1px solid #555;
-  border-radius: 4px;
-  font-size: 0.875rem;
-  cursor: pointer;
-}
-
-.vrm-canvas__debug-select:hover {
-  border-color: #777;
-}
-
-.vrm-canvas__debug-select:focus {
-  outline: none;
-  border-color: #0066cc;
-}
-
-.vrm-canvas__debug-hint {
-  font-size: 0.75rem;
-  color: #888;
-  font-style: italic;
-  max-width: 200px;
-}
-
-.vrm-canvas__springbone-toggle,
-.vrm-canvas__bones-toggle,
-.vrm-canvas__colliders-toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  cursor: pointer;
-  margin-top: 0.25rem;
-}
-
-.vrm-canvas__springbone-toggle input[type="checkbox"],
-.vrm-canvas__bones-toggle input[type="checkbox"],
-.vrm-canvas__colliders-toggle input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-}
-
-/* 表情パネル */
-.vrm-canvas__expression-panel {
-  position: absolute;
-  bottom: 50px;
-  left: 10px;
-  width: 280px;
-  max-height: 400px;
-  background-color: rgba(30, 30, 30, 0.95);
-  border: 1px solid #444;
-  border-radius: 6px;
-  z-index: 100;
-  color: #fff;
-  font-size: 0.875rem;
-  display: flex;
-  flex-direction: column;
-}
-
-.vrm-canvas__expression-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid #444;
-  font-weight: 500;
-}
-
-.vrm-canvas__expression-reset-btn {
-  padding: 0.25rem 0.5rem;
-  background-color: #555;
-  color: #fff;
-  border: none;
-  border-radius: 3px;
-  cursor: pointer;
-  font-size: 0.75rem;
-}
-
-.vrm-canvas__expression-reset-btn:hover {
-  background-color: #666;
-}
-
-.vrm-canvas__expression-list {
   overflow-y: auto;
-  padding: 0.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
+  padding: 0.75rem;
+  gap: 0.5rem;
+  background-color: var(--vrm-bg);
+  border-right: 1px solid var(--vrm-border);
+  color: var(--vrm-text);
+  font-size: 0.8125rem;
 }
 
-.vrm-canvas__expression-item {
-  display: grid;
-  grid-template-columns: 80px 1fr 40px;
+.vrm-sidebar__title {
+  flex: 0 0 auto;
+  margin: 0 0 0.25rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+/* ---------------- セクション ---------------- */
+
+.vrm-section {
+  /* サイドバーは flex コラム。既定の flex-shrink だとセクションが潰れて
+     中身が見切れるため、縮ませずサイドバー側をスクロールさせる */
+  flex: 0 0 auto;
+  border: 1px solid var(--vrm-border);
+  border-radius: 6px;
+  background-color: var(--vrm-bg-raised);
+  overflow: hidden;
+}
+
+.vrm-section__header {
+  display: flex;
   align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  border: none;
+  background: none;
+  color: var(--vrm-text);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.vrm-section__header:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.vrm-section__caret {
+  color: var(--vrm-text-dim);
+  font-size: 0.625rem;
+}
+
+.vrm-section__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 0 0.625rem 0.625rem;
+}
+
+/* ---------------- ボタン ---------------- */
+
+.vrm-btn {
+  padding: 0.4rem 0.625rem;
+  border: 1px solid var(--vrm-border);
+  border-radius: 4px;
+  background-color: #333;
+  color: var(--vrm-text);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: background-color 0.12s, opacity 0.12s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vrm-btn:hover:not(:disabled) {
+  background-color: #414141;
+}
+
+.vrm-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.vrm-btn--primary { background-color: var(--vrm-accent); border-color: transparent; }
+.vrm-btn--primary:hover:not(:disabled) { background-color: #1f6ee0; }
+
+.vrm-btn--optimize { background-color: #2f6f9f; border-color: transparent; }
+.vrm-btn--optimize:hover:not(:disabled) { background-color: #3a83b9; }
+
+.vrm-btn--migrate { background-color: #9f6a2f; border-color: transparent; }
+.vrm-btn--migrate:hover:not(:disabled) { background-color: #b97e3a; }
+
+.vrm-btn--simplify { background-color: #6a3f9f; border-color: transparent; }
+.vrm-btn--simplify:hover:not(:disabled) { background-color: #7e4cb9; }
+
+.vrm-btn--export { background-color: #2f7f5f; border-color: transparent; }
+.vrm-btn--export:hover:not(:disabled) { background-color: #379470; }
+
+.vrm-btn--tool { font-size: 0.75rem; padding: 0.3rem 0.4rem; }
+
+.vrm-btn-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.375rem;
+}
+
+.vrm-btn-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.375rem;
+}
+
+/* ---------------- フォーム要素 ---------------- */
+
+.vrm-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
 }
 
-.vrm-canvas__expression-item label {
+/* ラベルを上に積む版。選択肢の文字列が長く、横並びだと見切れる項目に使う */
+.vrm-field--stack {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.25rem;
+}
+
+.vrm-field__label {
+  color: var(--vrm-text-dim);
+  white-space: nowrap;
+}
+
+.vrm-field__select {
+  flex: 1;
+  min-width: 0;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--vrm-border);
+  border-radius: 4px;
+  background-color: #333;
+  color: var(--vrm-text);
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.vrm-field__select:hover:not(:disabled) { background-color: #414141; }
+.vrm-field__select:focus { outline: 1px solid var(--vrm-accent); }
+.vrm-field__select:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.vrm-checks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.125rem;
+}
+
+.vrm-check {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.vrm-check input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  accent-color: var(--vrm-accent);
+  cursor: pointer;
+}
+
+/* ---------------- 補助テキスト・統計 ---------------- */
+
+.vrm-note {
+  margin: 0;
+  color: var(--vrm-text-dim);
   font-size: 0.75rem;
-  color: #ccc;
+  line-height: 1.4;
+}
+
+.vrm-note strong {
+  color: var(--vrm-text);
+  font-weight: 600;
+}
+
+.vrm-stats {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.125rem 0.5rem;
+  margin: 0.25rem 0 0;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.vrm-stats dt { color: var(--vrm-text-dim); white-space: nowrap; }
+.vrm-stats dd { margin: 0; }
+.vrm-stats__sub { color: var(--vrm-text-dim); }
+
+/* ---------------- 表情スライダー ---------------- */
+
+.vrm-expressions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.vrm-expression {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr 2.25rem;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.vrm-expression__name {
+  color: var(--vrm-text-dim);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.vrm-canvas__expression-item input[type="range"] {
+.vrm-expression input[type="range"] {
   width: 100%;
-  height: 4px;
+  accent-color: var(--vrm-accent);
   cursor: pointer;
 }
 
-.vrm-canvas__expression-value {
-  font-size: 0.7rem;
-  color: #888;
+.vrm-expression__value {
+  color: var(--vrm-text-dim);
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
   text-align: right;
-  font-family: monospace;
 }
 
-/* アトラス設定パネル */
-.vrm-canvas__atlas-panel {
+/* ---------------- ビューポート上のオーバーレイ ---------------- */
+
+.vrm-canvas__error {
   position: absolute;
-  top: 70px;
-  right: 10px;
-  padding: 0.75rem 1rem;
-  background-color: rgba(30, 30, 30, 0.95);
-  border: 1px solid #444;
-  border-radius: 6px;
-  z-index: 100;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 0.625rem 0.875rem;
+  background-color: #c41c3b;
   color: #fff;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
+  z-index: 10;
 }
 
-.vrm-canvas__atlas-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-  font-weight: 500;
-  gap: 1rem;
-}
-
-.vrm-canvas__file-size {
-  font-size: 0.75rem;
-  color: #4caf50;
-  font-weight: 600;
-}
-
-.vrm-canvas__atlas-options {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.vrm-canvas__atlas-options label {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.75rem;
-  color: #ccc;
-}
-
-.vrm-canvas__atlas-options select {
-  padding: 0.25rem 0.4rem;
-  background-color: #2a2a2a;
-  color: #fff;
-  border: 1px solid #555;
-  border-radius: 3px;
-  font-size: 0.75rem;
-  cursor: pointer;
-}
-
-.vrm-canvas__atlas-options select:hover {
-  border-color: #777;
-}
-
-.vrm-canvas__atlas-options select:focus {
-  outline: none;
-  border-color: #0066cc;
-}
-
-/* Simplify統計パネル */
-.vrm-canvas__simplify-panel {
+.vrm-canvas__status {
   position: absolute;
-  top: 70px;
-  left: 10px;
-  padding: 0.75rem 1rem;
-  background-color: rgba(30, 30, 30, 0.95);
-  border: 1px solid #9f4aff;
-  border-radius: 6px;
-  z-index: 100;
-  color: #fff;
-  font-size: 0.875rem;
-  max-width: 400px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.5rem 0.875rem;
+  background-color: rgba(30, 30, 30, 0.9);
+  border-top: 1px solid var(--vrm-border);
+  color: var(--vrm-text);
+  font-size: 0.8125rem;
+  z-index: 10;
 }
 
-.vrm-canvas__simplify-header {
-  margin-bottom: 0.5rem;
-  font-weight: 500;
-  color: #9f4aff;
+/* ---------------- スクロールバー ---------------- */
+
+.vrm-sidebar::-webkit-scrollbar,
+.vrm-expressions::-webkit-scrollbar {
+  width: 8px;
 }
 
-.vrm-canvas__simplify-stats {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  font-size: 0.75rem;
-  color: #ccc;
-}
-
-.vrm-canvas__simplify-stats div {
-  font-family: monospace;
-}
-
-/* Spector.js キャプチャボタン */
-.vrm-canvas__spector-btn {
-  margin-left: 0.75rem;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
-  background-color: #2d5a27;
-  color: #fff;
-  border: 1px solid #4a9d40;
+.vrm-sidebar::-webkit-scrollbar-thumb,
+.vrm-expressions::-webkit-scrollbar-thumb {
+  background-color: #454545;
   border-radius: 4px;
-  cursor: pointer;
-  transition: background-color 0.2s;
 }
 
-.vrm-canvas__spector-btn:hover {
-  background-color: #3a7a30;
-}
-
-.vrm-canvas__spector-btn:active {
-  background-color: #1e4a1a;
-}
-
-/* WebGLデバッグボタン（PlaywrightMCP用コンソール出力） */
-.vrm-canvas__debug-btn {
-  margin-left: 0.5rem;
-  padding: 0.25rem 0.4rem;
-  font-size: 0.65rem;
-  background-color: #4a3a6a;
-  color: #fff;
-  border: 1px solid #7a5aaa;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.vrm-canvas__debug-btn:hover {
-  background-color: #5a4a7a;
-}
-
-.vrm-canvas__debug-btn:active {
-  background-color: #3a2a5a;
+.vrm-sidebar::-webkit-scrollbar-track,
+.vrm-expressions::-webkit-scrollbar-track {
+  background-color: transparent;
 }

--- a/packages/debug-viewer/src/components/VRMCanvas.css
+++ b/packages/debug-viewer/src/components/VRMCanvas.css
@@ -43,6 +43,12 @@
   font-size: 0.8125rem;
 }
 
+/* 3D Viewport 以外のタブでは隠す。
+   .vrm-sidebar の display:flex が hidden 属性の既定値を上書きするため明示する */
+.vrm-sidebar[hidden] {
+  display: none;
+}
+
 .vrm-sidebar__title {
   flex: 0 0 auto;
   margin: 0 0 0.25rem;

--- a/packages/debug-viewer/src/components/VRMCanvas.tsx
+++ b/packages/debug-viewer/src/components/VRMCanvas.tsx
@@ -12,8 +12,12 @@ import { useWebGLDebug } from '../hooks/useWebGLDebug'
 import './VRMCanvas.css'
 
 
-/** Debug Mode ごとの説明文 */
-const DEBUG_MODE_HINTS: Record<string, string> = {
+/**
+ * Debug Mode ごとの説明文
+ * Record<DebugMode, string> にしているのは、DebugMode が増えたときに
+ * 説明文の追加漏れをコンパイルエラーで検出するため
+ */
+const DEBUG_MODE_HINTS: Record<DebugMode, string> = {
   none: '通常描画',
   uv: 'UV座標を可視化 (RG=UV)',
   normal: 'ワールド法線を可視化',
@@ -26,6 +30,7 @@ const DEBUG_MODE_HINTS: Record<string, string> = {
   shadingParams: 'shadingShift(R)/shadingToony(G)/raw(B)',
   paramRaw: 'R=shadingShift, G=shadingToony, B=slot',
   litShadeRate: '明暗グラデーション',
+  alpha: 'アルファ値 (R=最終, G=opacity, B=テクスチャ)',
 }
 
 /** アトラス解像度を設定できるスロット */
@@ -296,7 +301,6 @@ function VRMCanvas({
   onSelectModel,
 }: VRMCanvasProps)
 {
-  const canvasContainerRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [canvasElement, setCanvasElement] = useState<HTMLCanvasElement | null>(null)
   const [glRenderer, setGlRenderer] = useState<WebGLRenderer | null>(null)
@@ -344,270 +348,269 @@ function VRMCanvas({
   }, [])
 
   return (
-    <div className="vrm-canvas" ref={canvasContainerRef}>
-      {/* 3D Viewport タブのときのみサイドバーを表示 */}
-      {currentTab === 0 && (
-        <aside className="vrm-sidebar">
-          <h1 className="vrm-sidebar__title">VRM Debug Viewer</h1>
+    <div className="vrm-canvas">
+      {/* 3D Viewport タブ以外では隠すだけにする。
+          unmount するとセクションの開閉状態とスクロール位置が毎回リセットされる */}
+      <aside className="vrm-sidebar" hidden={currentTab !== 0}>
+        <h1 className="vrm-sidebar__title">VRM Debug Viewer</h1>
 
-          <Section title="モデル" defaultOpen>
+        <Section title="モデル" defaultOpen>
+          <select
+            className="vrm-field__select"
+            value={selectedModel}
+            onChange={(e) => onSelectModel(e.target.value)}
+            disabled={isLoading}
+          >
+            {defaultModels.map((model) => (
+              <option key={model.path} value={model.path}>
+                {model.name}
+              </option>
+            ))}
+          </select>
+          <button
+            className="vrm-btn"
+            onClick={handleButtonClick}
+            disabled={isLoading}
+          >
+            {isLoading ? 'Loading...' : 'Upload VRM'}
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".vrm"
+            onChange={onFileChange}
+            style={{ display: 'none' }}
+          />
+        </Section>
+
+        <Section title="最適化" defaultOpen>
+          <button
+            className="vrm-btn vrm-btn--primary"
+            onClick={onOptimize}
+            disabled={!vrm || isOptimizing}
+          >
+            {isOptimizing ? 'Optimizing...' : 'Optimize + Migrate'}
+          </button>
+          <div className="vrm-btn-row">
+            <button
+              className="vrm-btn vrm-btn--optimize"
+              onClick={onOptimizeOnly}
+              disabled={!vrm || isOptimizing}
+            >
+              Optimize
+            </button>
+            <button
+              className="vrm-btn vrm-btn--migrate"
+              onClick={onMigrateOnly}
+              disabled={!vrm}
+            >
+              Migrate
+            </button>
+          </div>
+          <button
+            className="vrm-btn vrm-btn--simplify"
+            onClick={onSimplifyOnly}
+            disabled={!vrm || isSimplifying}
+          >
+            {isSimplifying ? 'Simplifying...' : 'Simplify Only'}
+          </button>
+          {lastSimplifyStats && (
+            <dl className="vrm-stats">
+              <dt>メッシュ</dt>
+              <dd>
+                {lastSimplifyStats.processedMeshCount} 処理
+                <span className="vrm-stats__sub">
+                  / {lastSimplifyStats.skippedMeshCount} スキップ
+                </span>
+              </dd>
+              <dt>頂点</dt>
+              <dd>
+                {lastSimplifyStats.originalVertexCount.toLocaleString()} →{' '}
+                {lastSimplifyStats.simplifiedVertexCount.toLocaleString()}
+                <span className="vrm-stats__sub">
+                  {' '}({(lastSimplifyStats.vertexReductionRatio * 100).toFixed(1)}% 削減)
+                </span>
+              </dd>
+              <dt>インデックス</dt>
+              <dd>
+                {lastSimplifyStats.originalIndexCount.toLocaleString()} →{' '}
+                {lastSimplifyStats.simplifiedIndexCount.toLocaleString()}
+                <span className="vrm-stats__sub">
+                  {' '}({(lastSimplifyStats.indexReductionRatio * 100).toFixed(1)}% 削減)
+                </span>
+              </dd>
+            </dl>
+          )}
+        </Section>
+
+        <Section title="エクスポート" defaultOpen>
+          <button
+            className="vrm-btn vrm-btn--export"
+            onClick={onExportGLTF}
+            disabled={!vrm}
+          >
+            Export VRM
+          </button>
+          <button
+            className="vrm-btn"
+            onClick={onReloadExport}
+            disabled={!vrm || isReloading}
+            title="エクスポート結果をファイルに出さずそのまま読み直す"
+          >
+            {isReloading ? 'Reloading...' : 'Reload Export'}
+          </button>
+          <button
+            className="vrm-btn"
+            onClick={onExportScene}
+            disabled={!vrm}
+          >
+            Export Scene
+          </button>
+          {lastExportSize !== null && (
+            <p className="vrm-note">
+              Last export: <strong>{(lastExportSize / 1024 / 1024).toFixed(2)} MB</strong>
+            </p>
+          )}
+        </Section>
+
+        <Section title="表示設定">
+          <label className="vrm-field vrm-field--stack">
+            <span className="vrm-field__label">Debug Mode</span>
             <select
               className="vrm-field__select"
-              value={selectedModel}
-              onChange={(e) => onSelectModel(e.target.value)}
-              disabled={isLoading}
+              value={debugMode}
+              onChange={(e) => onDebugModeChange(e.target.value as DebugMode)}
             >
-              {defaultModels.map((model) => (
-                <option key={model.path} value={model.path}>
-                  {model.name}
+              {MToonAtlasMaterial.getAvailableDebugModes().map((mode) => (
+                <option key={mode} value={mode}>
+                  {mode === 'none' ? 'None (Normal)' : mode}
                 </option>
               ))}
             </select>
-            <button
-              className="vrm-btn"
-              onClick={handleButtonClick}
-              disabled={isLoading}
-            >
-              {isLoading ? 'Loading...' : 'Upload VRM'}
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".vrm"
-              onChange={onFileChange}
-              style={{ display: 'none' }}
-            />
-          </Section>
+          </label>
+          {DEBUG_MODE_HINTS[debugMode] && (
+            <p className="vrm-note">{DEBUG_MODE_HINTS[debugMode]}</p>
+          )}
+          <div className="vrm-checks">
+            <label className="vrm-check">
+              <input
+                type="checkbox"
+                checked={springBoneEnabled}
+                onChange={(e) => onSpringBoneEnabledChange(e.target.checked)}
+              />
+              SpringBone
+            </label>
+            <label className="vrm-check">
+              <input
+                type="checkbox"
+                checked={showBones}
+                onChange={(e) => onShowBonesChange(e.target.checked)}
+              />
+              Show Bones
+            </label>
+            <label className="vrm-check">
+              <input
+                type="checkbox"
+                checked={showColliders}
+                onChange={(e) => onShowCollidersChange(e.target.checked)}
+              />
+              Show Colliders
+            </label>
+            <label className="vrm-check">
+              <input
+                type="checkbox"
+                checked={showPointLights}
+                onChange={(e) => onShowPointLightsChange(e.target.checked)}
+              />
+              Point Lights
+            </label>
+            <label className="vrm-check">
+              <input
+                type="checkbox"
+                checked={logShaderInfo}
+                onChange={(e) => onLogShaderInfoChange(e.target.checked)}
+              />
+              Log Shader
+            </label>
+          </div>
+        </Section>
 
-          <Section title="最適化" defaultOpen>
-            <button
-              className="vrm-btn vrm-btn--primary"
-              onClick={onOptimize}
-              disabled={!vrm || isOptimizing}
-            >
-              {isOptimizing ? 'Optimizing...' : 'Optimize + Migrate'}
-            </button>
-            <div className="vrm-btn-row">
-              <button
-                className="vrm-btn vrm-btn--optimize"
-                onClick={onOptimizeOnly}
-                disabled={!vrm || isOptimizing}
-              >
-                Optimize
-              </button>
-              <button
-                className="vrm-btn vrm-btn--migrate"
-                onClick={onMigrateOnly}
-                disabled={!vrm}
-              >
-                Migrate
-              </button>
-            </div>
-            <button
-              className="vrm-btn vrm-btn--simplify"
-              onClick={onSimplifyOnly}
-              disabled={!vrm || isSimplifying}
-            >
-              {isSimplifying ? 'Simplifying...' : 'Simplify Only'}
-            </button>
-            {lastSimplifyStats && (
-              <dl className="vrm-stats">
-                <dt>メッシュ</dt>
-                <dd>
-                  {lastSimplifyStats.processedMeshCount} 処理
-                  <span className="vrm-stats__sub">
-                    / {lastSimplifyStats.skippedMeshCount} スキップ
-                  </span>
-                </dd>
-                <dt>頂点</dt>
-                <dd>
-                  {lastSimplifyStats.originalVertexCount.toLocaleString()} →{' '}
-                  {lastSimplifyStats.simplifiedVertexCount.toLocaleString()}
-                  <span className="vrm-stats__sub">
-                    {' '}({(lastSimplifyStats.vertexReductionRatio * 100).toFixed(1)}% 削減)
-                  </span>
-                </dd>
-                <dt>インデックス</dt>
-                <dd>
-                  {lastSimplifyStats.originalIndexCount.toLocaleString()} →{' '}
-                  {lastSimplifyStats.simplifiedIndexCount.toLocaleString()}
-                  <span className="vrm-stats__sub">
-                    {' '}({(lastSimplifyStats.indexReductionRatio * 100).toFixed(1)}% 削減)
-                  </span>
-                </dd>
-              </dl>
-            )}
-          </Section>
-
-          <Section title="エクスポート" defaultOpen>
-            <button
-              className="vrm-btn vrm-btn--export"
-              onClick={onExportGLTF}
-              disabled={!vrm}
-            >
-              Export VRM
-            </button>
-            <button
-              className="vrm-btn"
-              onClick={onReloadExport}
-              disabled={!vrm || isReloading}
-              title="エクスポート結果をファイルに出さずそのまま読み直す"
-            >
-              {isReloading ? 'Reloading...' : 'Reload Export'}
-            </button>
-            <button
-              className="vrm-btn"
-              onClick={onExportScene}
-              disabled={!vrm}
-            >
-              Export Scene
-            </button>
-            {lastExportSize !== null && (
-              <p className="vrm-note">
-                Last export: <strong>{(lastExportSize / 1024 / 1024).toFixed(2)} MB</strong>
-              </p>
-            )}
-          </Section>
-
-          <Section title="表示設定">
-            <label className="vrm-field vrm-field--stack">
-              <span className="vrm-field__label">Debug Mode</span>
+        <Section title="アトラス解像度">
+          {ATLAS_SLOTS.map(({ key, label }) => (
+            <label className="vrm-field" key={key}>
+              <span className="vrm-field__label">{label}</span>
               <select
                 className="vrm-field__select"
-                value={debugMode}
-                onChange={(e) => onDebugModeChange(e.target.value as DebugMode)}
+                value={
+                  key === 'default'
+                    ? atlasOptions.defaultResolution ?? 2048
+                    : atlasOptions.slotResolutions?.[key] ?? ''
+                }
+                onChange={(e) => onAtlasOptionsChange(
+                  updateAtlasOption(atlasOptions, key, e.target.value)
+                )}
               >
-                {MToonAtlasMaterial.getAvailableDebugModes().map((mode) => (
-                  <option key={mode} value={mode}>
-                    {mode === 'none' ? 'None (Normal)' : mode}
-                  </option>
+                {key !== 'default' && <option value="">default</option>}
+                {ATLAS_RESOLUTIONS.map((res) => (
+                  <option key={res} value={res}>{res}</option>
                 ))}
               </select>
             </label>
-            {DEBUG_MODE_HINTS[debugMode] && (
-              <p className="vrm-note">{DEBUG_MODE_HINTS[debugMode]}</p>
+          ))}
+        </Section>
+
+        {vrm?.expressionManager && (
+          <ExpressionSection key={vrm.scene.uuid} vrm={vrm} />
+        )}
+
+        <Section title="その他">
+          <button
+            className="vrm-btn"
+            onClick={onReplaceTextures}
+            disabled={!vrm || isReplacingTextures}
+          >
+            {isReplacingTextures ? 'Replacing...' : 'Replace Textures with UV'}
+          </button>
+          <button
+            className="vrm-btn"
+            onClick={onPlayAnimation}
+            disabled={!vrm || !!vrmAnimation}
+          >
+            {vrmAnimation ? 'Playing Animation' : 'Play Animation'}
+          </button>
+        </Section>
+
+        {(isSpectorReady || glRenderer) && (
+          <Section title="WebGL ツール">
+            {isSpectorReady && (
+              <div className="vrm-btn-row">
+                <button className="vrm-btn vrm-btn--tool" onClick={captureFrame} title="Spector.jsでフレームをキャプチャ">
+                  Capture Frame
+                </button>
+                <button className="vrm-btn vrm-btn--tool" onClick={displaySpectorUI} title="Spector.js UIを表示">
+                  Spector UI
+                </button>
+              </div>
             )}
-            <div className="vrm-checks">
-              <label className="vrm-check">
-                <input
-                  type="checkbox"
-                  checked={springBoneEnabled}
-                  onChange={(e) => onSpringBoneEnabledChange(e.target.checked)}
-                />
-                SpringBone
-              </label>
-              <label className="vrm-check">
-                <input
-                  type="checkbox"
-                  checked={showBones}
-                  onChange={(e) => onShowBonesChange(e.target.checked)}
-                />
-                Show Bones
-              </label>
-              <label className="vrm-check">
-                <input
-                  type="checkbox"
-                  checked={showColliders}
-                  onChange={(e) => onShowCollidersChange(e.target.checked)}
-                />
-                Show Colliders
-              </label>
-              <label className="vrm-check">
-                <input
-                  type="checkbox"
-                  checked={showPointLights}
-                  onChange={(e) => onShowPointLightsChange(e.target.checked)}
-                />
-                Point Lights
-              </label>
-              <label className="vrm-check">
-                <input
-                  type="checkbox"
-                  checked={logShaderInfo}
-                  onChange={(e) => onLogShaderInfoChange(e.target.checked)}
-                />
-                Log Shader
-              </label>
-            </div>
+            {glRenderer && (
+              <div className="vrm-btn-grid">
+                <button className="vrm-btn vrm-btn--tool" onClick={handleListTextures} title="テクスチャ一覧をコンソール出力">
+                  List Tex
+                </button>
+                <button className="vrm-btn vrm-btn--tool" onClick={handleDumpFirstTexture} title="最初のテクスチャをBase64でコンソール出力">
+                  Dump Tex
+                </button>
+                <button className="vrm-btn vrm-btn--tool" onClick={handleDumpFramebuffer} title="フレームバッファをBase64でコンソール出力">
+                  Dump FB
+                </button>
+                <button className="vrm-btn vrm-btn--tool" onClick={handleDumpWebGLInfo} title="WebGL情報をコンソール出力">
+                  GL Info
+                </button>
+              </div>
+            )}
           </Section>
-
-          <Section title="アトラス解像度">
-            {ATLAS_SLOTS.map(({ key, label }) => (
-              <label className="vrm-field" key={key}>
-                <span className="vrm-field__label">{label}</span>
-                <select
-                  className="vrm-field__select"
-                  value={
-                    key === 'default'
-                      ? atlasOptions.defaultResolution ?? 2048
-                      : atlasOptions.slotResolutions?.[key] ?? ''
-                  }
-                  onChange={(e) => onAtlasOptionsChange(
-                    updateAtlasOption(atlasOptions, key, e.target.value)
-                  )}
-                >
-                  {key !== 'default' && <option value="">default</option>}
-                  {ATLAS_RESOLUTIONS.map((res) => (
-                    <option key={res} value={res}>{res}</option>
-                  ))}
-                </select>
-              </label>
-            ))}
-          </Section>
-
-          {vrm?.expressionManager && (
-            <ExpressionSection key={vrm.scene.uuid} vrm={vrm} />
-          )}
-
-          <Section title="その他">
-            <button
-              className="vrm-btn"
-              onClick={onReplaceTextures}
-              disabled={!vrm || isReplacingTextures}
-            >
-              {isReplacingTextures ? 'Replacing...' : 'Replace Textures with UV'}
-            </button>
-            <button
-              className="vrm-btn"
-              onClick={onPlayAnimation}
-              disabled={!vrm || !!vrmAnimation}
-            >
-              {vrmAnimation ? 'Playing Animation' : 'Play Animation'}
-            </button>
-          </Section>
-
-          {(isSpectorReady || glRenderer) && (
-            <Section title="WebGL ツール">
-              {isSpectorReady && (
-                <div className="vrm-btn-row">
-                  <button className="vrm-btn vrm-btn--tool" onClick={captureFrame} title="Spector.jsでフレームをキャプチャ">
-                    Capture Frame
-                  </button>
-                  <button className="vrm-btn vrm-btn--tool" onClick={displaySpectorUI} title="Spector.js UIを表示">
-                    Spector UI
-                  </button>
-                </div>
-              )}
-              {glRenderer && (
-                <div className="vrm-btn-grid">
-                  <button className="vrm-btn vrm-btn--tool" onClick={handleListTextures} title="テクスチャ一覧をコンソール出力">
-                    List Tex
-                  </button>
-                  <button className="vrm-btn vrm-btn--tool" onClick={handleDumpFirstTexture} title="最初のテクスチャをBase64でコンソール出力">
-                    Dump Tex
-                  </button>
-                  <button className="vrm-btn vrm-btn--tool" onClick={handleDumpFramebuffer} title="フレームバッファをBase64でコンソール出力">
-                    Dump FB
-                  </button>
-                  <button className="vrm-btn vrm-btn--tool" onClick={handleDumpWebGLInfo} title="WebGL情報をコンソール出力">
-                    GL Info
-                  </button>
-                </div>
-              )}
-            </Section>
-          )}
-        </aside>
-      )}
+        )}
+      </aside>
 
       <div className="vrm-canvas__viewport">
         <Canvas

--- a/packages/debug-viewer/src/components/VRMCanvas.tsx
+++ b/packages/debug-viewer/src/components/VRMCanvas.tsx
@@ -11,11 +11,102 @@ import { useWebGLDebug } from '../hooks/useWebGLDebug'
 
 import './VRMCanvas.css'
 
+
+/** Debug Mode ごとの説明文 */
+const DEBUG_MODE_HINTS: Record<string, string> = {
+  none: '通常描画',
+  uv: 'UV座標を可視化 (RG=UV)',
+  normal: 'ワールド法線を可視化',
+  shadow: 'シャドウ座標を可視化 (黄色=無効)',
+  shadowValue: 'シャドウ値 (白=影なし、黒=影あり)',
+  receiveShadow: 'receiveShadow (緑=有効、赤=無効)',
+  lightDir: 'ライト方向を可視化',
+  dotNL: '法線・ライト内積 (NdotL)',
+  shading: 'MToonシェーディング結果',
+  shadingParams: 'shadingShift(R)/shadingToony(G)/raw(B)',
+  paramRaw: 'R=shadingShift, G=shadingToony, B=slot',
+  litShadeRate: '明暗グラデーション',
+}
+
+/** アトラス解像度を設定できるスロット */
+const ATLAS_SLOTS = [
+  { key: 'default', label: 'Default' },
+  { key: 'map', label: 'map' },
+  { key: 'normalMap', label: 'normalMap' },
+  { key: 'emissiveMap', label: 'emissiveMap' },
+] as const
+
+const ATLAS_RESOLUTIONS = [512, 1024, 2048, 4096] as const
+
+type AtlasSlotKey = (typeof ATLAS_SLOTS)[number]['key']
+
 /**
- * VRM表情（モーフ）確認用パネル
+ * アトラス解像度オプションを更新した新しいオブジェクトを返す
+ * 空文字（default）が選ばれたスロットはキーごと取り除く
+ *
+ * @param options - 現在のオプション
+ * @param key - 更新するスロット（'default' は全体の既定値）
+ * @param rawValue - select の値。'' は既定値に戻すことを表す
+ */
+function updateAtlasOption(
+  options: AtlasGenerationOptions,
+  key: AtlasSlotKey,
+  rawValue: string,
+): AtlasGenerationOptions
+{
+  if (key === 'default')
+  {
+    return { ...options, defaultResolution: Number(rawValue) }
+  }
+
+  const slotResolutions = { ...options.slotResolutions }
+  if (rawValue === '')
+  {
+    delete slotResolutions[key]
+  } else
+  {
+    slotResolutions[key] = Number(rawValue)
+  }
+  return { ...options, slotResolutions }
+}
+
+/**
+ * サイドバーの折りたたみセクション
+ * 見出しクリックで開閉する
+ */
+function Section({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string
+  defaultOpen?: boolean
+  children: React.ReactNode
+})
+{
+  const [open, setOpen] = useState(defaultOpen)
+
+  return (
+    <section className="vrm-section">
+      <button
+        type="button"
+        className="vrm-section__header"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+      >
+        <span className="vrm-section__caret" aria-hidden="true">{open ? '▼' : '▶'}</span>
+        {title}
+      </button>
+      {open && <div className="vrm-section__body">{children}</div>}
+    </section>
+  )
+}
+
+/**
+ * VRM表情（モーフ）確認用セクション
  * expressionManagerから利用可能な表情一覧を取得し、スライダーで調整可能
  */
-function ExpressionPanel({ vrm }: { vrm: VRM })
+function ExpressionSection({ vrm }: { vrm: VRM })
 {
   const [expressionValues, setExpressionValues] = useState<Record<string, number>>({})
   const expressionNames = useMemo(() =>
@@ -68,21 +159,16 @@ function ExpressionPanel({ vrm }: { vrm: VRM })
   }
 
   return (
-    <div className="vrm-canvas__expression-panel">
-      <div className="vrm-canvas__expression-header">
-        <span>Expressions ({expressionNames.length})</span>
-        <button
-          className="vrm-canvas__expression-reset-btn"
-          onClick={handleResetAll}
-        >
-          Reset
-        </button>
-      </div>
-      <div className="vrm-canvas__expression-list">
+    <Section title={`表情 (${expressionNames.length})`}>
+      <button className="vrm-btn" onClick={handleResetAll}>
+        すべてリセット
+      </button>
+      <div className="vrm-expressions">
         {expressionNames.map((name) => (
-          <div key={name} className="vrm-canvas__expression-item">
-            <label>{name}</label>
+          <div key={name} className="vrm-expression">
+            <label className="vrm-expression__name" htmlFor={`expr-${name}`}>{name}</label>
             <input
+              id={`expr-${name}`}
               type="range"
               min="0"
               max="1"
@@ -90,13 +176,13 @@ function ExpressionPanel({ vrm }: { vrm: VRM })
               value={expressionValues[name] ?? 0}
               onChange={(e) => handleExpressionChange(name, parseFloat(e.target.value))}
             />
-            <span className="vrm-canvas__expression-value">
+            <span className="vrm-expression__value">
               {(expressionValues[name] ?? 0).toFixed(2)}
             </span>
           </div>
         ))}
       </div>
-    </div>
+    </Section>
   )
 }
 
@@ -258,44 +344,15 @@ function VRMCanvas({
   }, [])
 
   return (
-    <div
-      ref={canvasContainerRef}
-      style={{
-        width: '100%',
-        height: '100%',
-        position: 'relative',
-      }}
-    >
-      <Canvas
-        shadows
-        camera={{
-          position: [0, 1.5, 3],
-          fov: 45,
-          near: 0.1,
-          far: 100,
-        }}
-        gl={{
-          antialias: true,
-          alpha: true,
-        }}
-        onCreated={({ gl }) =>
-        {
-          gl.shadowMap.type = 2 // THREE.PCFSoftShadowMap
-          setCanvasElement(gl.domElement)
-          setGlRenderer(gl)
-        }}
-      >
-        <CameraAspectUpdater />
-        <VRMScene vrm={vrm} vrmAnimation={vrmAnimation} debugMode={debugMode} springBoneEnabled={springBoneEnabled} showBones={showBones} showColliders={showColliders} showPointLights={showPointLights} logShaderInfo={logShaderInfo} />
-      </Canvas>
-
-      {/* 3D Viewport タブのときのみ UI を表示 */}
+    <div className="vrm-canvas" ref={canvasContainerRef}>
+      {/* 3D Viewport タブのときのみサイドバーを表示 */}
       {currentTab === 0 && (
-        <>
-          <div className="vrm-canvas__header">
-            <h1>VRM Debug Viewer</h1>
+        <aside className="vrm-sidebar">
+          <h1 className="vrm-sidebar__title">VRM Debug Viewer</h1>
+
+          <Section title="モデル" defaultOpen>
             <select
-              className="vrm-canvas__model-select"
+              className="vrm-field__select"
               value={selectedModel}
               onChange={(e) => onSelectModel(e.target.value)}
               disabled={isLoading}
@@ -307,77 +364,11 @@ function VRMCanvas({
               ))}
             </select>
             <button
-              className="vrm-canvas__upload-btn"
+              className="vrm-btn"
               onClick={handleButtonClick}
               disabled={isLoading}
             >
               {isLoading ? 'Loading...' : 'Upload VRM'}
-            </button>
-            <button
-              className="vrm-canvas__optimize-btn"
-              onClick={onOptimize}
-              disabled={!vrm || isOptimizing}
-            >
-              {isOptimizing ? 'Optimizing...' : 'Optimize + Migrate'}
-            </button>
-            <button
-              className="vrm-canvas__optimize-btn"
-              onClick={onOptimizeOnly}
-              disabled={!vrm || isOptimizing}
-              style={{ backgroundColor: '#4a9eff' }}
-            >
-              Optimize Only
-            </button>
-            <button
-              className="vrm-canvas__optimize-btn"
-              onClick={onMigrateOnly}
-              disabled={!vrm}
-              style={{ backgroundColor: '#ff9f4a' }}
-            >
-              Migrate Only
-            </button>
-            <button
-              className="vrm-canvas__optimize-btn"
-              onClick={onSimplifyOnly}
-              disabled={!vrm || isSimplifying}
-              style={{ backgroundColor: '#9f4aff' }}
-            >
-              {isSimplifying ? 'Simplifying...' : 'Simplify Only'}
-            </button>
-            <button
-              className="vrm-canvas__export-btn"
-              onClick={onExportScene}
-              disabled={!vrm}
-            >
-              Export Scene
-            </button>
-            <button
-              className="vrm-canvas__export-gltf-btn"
-              onClick={onExportGLTF}
-              disabled={!vrm}
-            >
-              Export VRM
-            </button>
-            <button
-              className="vrm-canvas__reload-export-btn"
-              onClick={onReloadExport}
-              disabled={!vrm || isReloading}
-            >
-              {isReloading ? 'Reloading...' : 'Reload Export'}
-            </button>
-            <button
-              className="vrm-canvas__replace-textures-btn"
-              onClick={onReplaceTextures}
-              disabled={!vrm || isReplacingTextures}
-            >
-              {isReplacingTextures ? 'Replacing...' : 'Replace Textures with UV'}
-            </button>
-            <button
-              className="vrm-canvas__play-animation-btn"
-              onClick={onPlayAnimation}
-              disabled={!vrm || !!vrmAnimation}
-            >
-              {vrmAnimation ? 'Playing Animation' : 'Play Animation'}
             </button>
             <input
               ref={fileInputRef}
@@ -386,251 +377,272 @@ function VRMCanvas({
               onChange={onFileChange}
               style={{ display: 'none' }}
             />
-          </div>
+          </Section>
 
-          {error && <div className="vrm-canvas__error">{error}</div>}
-
-          {vrm && (
-            <div className="vrm-canvas__info">
-              <p>VRM loaded: {vrm.scene.name || 'Unnamed Model'}</p>
-            </div>
-          )}
-
-          {/* デバッグモード選択UI */}
-          <div className="vrm-canvas__debug-panel">
-            <label htmlFor="debug-mode-select">Debug Mode: </label>
-            <select
-              id="debug-mode-select"
-              value={debugMode}
-              onChange={(e) => onDebugModeChange(e.target.value as DebugMode)}
-              className="vrm-canvas__debug-select"
+          <Section title="最適化" defaultOpen>
+            <button
+              className="vrm-btn vrm-btn--primary"
+              onClick={onOptimize}
+              disabled={!vrm || isOptimizing}
             >
-              {MToonAtlasMaterial.getAvailableDebugModes().map((mode) => (
-                <option key={mode} value={mode}>
-                  {mode === 'none' ? 'None (Normal)' : mode}
-                </option>
-              ))}
-            </select>
-            <span className="vrm-canvas__debug-hint">
-              {debugMode === 'none' && '通常描画'}
-              {debugMode === 'uv' && 'UV座標を可視化 (RG=UV)'}
-              {debugMode === 'normal' && 'ワールド法線を可視化'}
-              {debugMode === 'shadow' && 'シャドウ座標を可視化 (黄色=無効)'}
-              {debugMode === 'shadowValue' && 'シャドウ値 (白=影なし、黒=影あり)'}
-              {debugMode === 'receiveShadow' && 'receiveShadow (緑=有効、赤=無効)'}
-              {debugMode === 'lightDir' && 'ライト方向を可視化'}
-              {debugMode === 'dotNL' && '法線・ライト内積 (NdotL)'}
-              {debugMode === 'shading' && 'MToonシェーディング結果'}
-              {debugMode === 'shadingParams' && 'shadingShift(R)/shadingToony(G)/raw(B)'}
-              {debugMode === 'paramRaw' && 'R=shadingShift, G=shadingToony, B=slot'}
-              {debugMode === 'litShadeRate' && '明暗グラデーション'}
-            </span>
-            <label className="vrm-canvas__springbone-toggle">
-              <input
-                type="checkbox"
-                checked={springBoneEnabled}
-                onChange={(e) => onSpringBoneEnabledChange(e.target.checked)}
-              />
-              SpringBone
-            </label>
-            <label className="vrm-canvas__bones-toggle">
-              <input
-                type="checkbox"
-                checked={showBones}
-                onChange={(e) => onShowBonesChange(e.target.checked)}
-              />
-              Show Bones
-            </label>
-            <label className="vrm-canvas__colliders-toggle">
-              <input
-                type="checkbox"
-                checked={showColliders}
-                onChange={(e) => onShowCollidersChange(e.target.checked)}
-              />
-              Show Colliders
-            </label>
-            <label className="vrm-canvas__pointlights-toggle">
-              <input
-                type="checkbox"
-                checked={showPointLights}
-                onChange={(e) => onShowPointLightsChange(e.target.checked)}
-              />
-              Point Lights
-            </label>
-            <label className="vrm-canvas__shaderlog-toggle">
-              <input
-                type="checkbox"
-                checked={logShaderInfo}
-                onChange={(e) => onLogShaderInfoChange(e.target.checked)}
-              />
-              Log Shader
-            </label>
-            {isSpectorReady && (
-              <>
-                <button
-                  className="vrm-canvas__spector-btn"
-                  onClick={captureFrame}
-                  title="Spector.jsでフレームをキャプチャ"
-                >
-                  Capture Frame
-                </button>
-                <button
-                  className="vrm-canvas__spector-btn"
-                  onClick={displaySpectorUI}
-                  title="Spector.js UIを表示"
-                >
-                  Spector UI
-                </button>
-              </>
+              {isOptimizing ? 'Optimizing...' : 'Optimize + Migrate'}
+            </button>
+            <div className="vrm-btn-row">
+              <button
+                className="vrm-btn vrm-btn--optimize"
+                onClick={onOptimizeOnly}
+                disabled={!vrm || isOptimizing}
+              >
+                Optimize
+              </button>
+              <button
+                className="vrm-btn vrm-btn--migrate"
+                onClick={onMigrateOnly}
+                disabled={!vrm}
+              >
+                Migrate
+              </button>
+            </div>
+            <button
+              className="vrm-btn vrm-btn--simplify"
+              onClick={onSimplifyOnly}
+              disabled={!vrm || isSimplifying}
+            >
+              {isSimplifying ? 'Simplifying...' : 'Simplify Only'}
+            </button>
+            {lastSimplifyStats && (
+              <dl className="vrm-stats">
+                <dt>メッシュ</dt>
+                <dd>
+                  {lastSimplifyStats.processedMeshCount} 処理
+                  <span className="vrm-stats__sub">
+                    / {lastSimplifyStats.skippedMeshCount} スキップ
+                  </span>
+                </dd>
+                <dt>頂点</dt>
+                <dd>
+                  {lastSimplifyStats.originalVertexCount.toLocaleString()} →{' '}
+                  {lastSimplifyStats.simplifiedVertexCount.toLocaleString()}
+                  <span className="vrm-stats__sub">
+                    {' '}({(lastSimplifyStats.vertexReductionRatio * 100).toFixed(1)}% 削減)
+                  </span>
+                </dd>
+                <dt>インデックス</dt>
+                <dd>
+                  {lastSimplifyStats.originalIndexCount.toLocaleString()} →{' '}
+                  {lastSimplifyStats.simplifiedIndexCount.toLocaleString()}
+                  <span className="vrm-stats__sub">
+                    {' '}({(lastSimplifyStats.indexReductionRatio * 100).toFixed(1)}% 削減)
+                  </span>
+                </dd>
+              </dl>
             )}
-            {/* WebGLデバッグ: コンソール出力ボタン（PlaywrightMCP用） */}
-            {glRenderer && (
-              <>
-                <button
-                  className="vrm-canvas__debug-btn"
-                  onClick={handleListTextures}
-                  title="テクスチャ一覧をコンソール出力"
-                >
-                  List Tex
-                </button>
-                <button
-                  className="vrm-canvas__debug-btn"
-                  onClick={handleDumpFirstTexture}
-                  title="最初のテクスチャをBase64でコンソール出力"
-                >
-                  Dump Tex
-                </button>
-                <button
-                  className="vrm-canvas__debug-btn"
-                  onClick={handleDumpFramebuffer}
-                  title="フレームバッファをBase64でコンソール出力"
-                >
-                  Dump FB
-                </button>
-                <button
-                  className="vrm-canvas__debug-btn"
-                  onClick={handleDumpWebGLInfo}
-                  title="WebGL情報をコンソール出力"
-                >
-                  GL Info
-                </button>
-              </>
+          </Section>
+
+          <Section title="エクスポート" defaultOpen>
+            <button
+              className="vrm-btn vrm-btn--export"
+              onClick={onExportGLTF}
+              disabled={!vrm}
+            >
+              Export VRM
+            </button>
+            <button
+              className="vrm-btn"
+              onClick={onReloadExport}
+              disabled={!vrm || isReloading}
+              title="エクスポート結果をファイルに出さずそのまま読み直す"
+            >
+              {isReloading ? 'Reloading...' : 'Reload Export'}
+            </button>
+            <button
+              className="vrm-btn"
+              onClick={onExportScene}
+              disabled={!vrm}
+            >
+              Export Scene
+            </button>
+            {lastExportSize !== null && (
+              <p className="vrm-note">
+                Last export: <strong>{(lastExportSize / 1024 / 1024).toFixed(2)} MB</strong>
+              </p>
             )}
-          </div>
+          </Section>
 
-          {/* アトラス解像度設定パネル */}
-          <div className="vrm-canvas__atlas-panel">
-            <div className="vrm-canvas__atlas-header">
-              <span>Atlas Resolution</span>
-              {lastExportSize !== null && (
-                <span className="vrm-canvas__file-size">
-                  Last export: {(lastExportSize / 1024 / 1024).toFixed(2)} MB
-                </span>
-              )}
-            </div>
-            <div className="vrm-canvas__atlas-options">
-              <label>
-                Default:
-                <select
-                  value={atlasOptions.defaultResolution ?? 2048}
-                  onChange={(e) => onAtlasOptionsChange({
-                    ...atlasOptions,
-                    defaultResolution: Number(e.target.value),
-                  })}
-                >
-                  <option value={512}>512</option>
-                  <option value={1024}>1024</option>
-                  <option value={2048}>2048</option>
-                  <option value={4096}>4096</option>
-                </select>
+          <Section title="表示設定">
+            <label className="vrm-field vrm-field--stack">
+              <span className="vrm-field__label">Debug Mode</span>
+              <select
+                className="vrm-field__select"
+                value={debugMode}
+                onChange={(e) => onDebugModeChange(e.target.value as DebugMode)}
+              >
+                {MToonAtlasMaterial.getAvailableDebugModes().map((mode) => (
+                  <option key={mode} value={mode}>
+                    {mode === 'none' ? 'None (Normal)' : mode}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {DEBUG_MODE_HINTS[debugMode] && (
+              <p className="vrm-note">{DEBUG_MODE_HINTS[debugMode]}</p>
+            )}
+            <div className="vrm-checks">
+              <label className="vrm-check">
+                <input
+                  type="checkbox"
+                  checked={springBoneEnabled}
+                  onChange={(e) => onSpringBoneEnabledChange(e.target.checked)}
+                />
+                SpringBone
               </label>
-              <label>
-                map:
-                <select
-                  value={atlasOptions.slotResolutions?.map ?? ''}
-                  onChange={(e) => {
-                    const val = e.target.value
-                    const newSlots = { ...atlasOptions.slotResolutions }
-                    if (val === '') {
-                      delete newSlots.map
-                    } else {
-                      newSlots.map = Number(val)
-                    }
-                    onAtlasOptionsChange({ ...atlasOptions, slotResolutions: newSlots })
-                  }}
-                >
-                  <option value="">default</option>
-                  <option value={512}>512</option>
-                  <option value={1024}>1024</option>
-                  <option value={2048}>2048</option>
-                  <option value={4096}>4096</option>
-                </select>
+              <label className="vrm-check">
+                <input
+                  type="checkbox"
+                  checked={showBones}
+                  onChange={(e) => onShowBonesChange(e.target.checked)}
+                />
+                Show Bones
               </label>
-              <label>
-                normalMap:
-                <select
-                  value={atlasOptions.slotResolutions?.normalMap ?? ''}
-                  onChange={(e) => {
-                    const val = e.target.value
-                    const newSlots = { ...atlasOptions.slotResolutions }
-                    if (val === '') {
-                      delete newSlots.normalMap
-                    } else {
-                      newSlots.normalMap = Number(val)
-                    }
-                    onAtlasOptionsChange({ ...atlasOptions, slotResolutions: newSlots })
-                  }}
-                >
-                  <option value="">default</option>
-                  <option value={512}>512</option>
-                  <option value={1024}>1024</option>
-                  <option value={2048}>2048</option>
-                  <option value={4096}>4096</option>
-                </select>
+              <label className="vrm-check">
+                <input
+                  type="checkbox"
+                  checked={showColliders}
+                  onChange={(e) => onShowCollidersChange(e.target.checked)}
+                />
+                Show Colliders
               </label>
-              <label>
-                emissiveMap:
-                <select
-                  value={atlasOptions.slotResolutions?.emissiveMap ?? ''}
-                  onChange={(e) => {
-                    const val = e.target.value
-                    const newSlots = { ...atlasOptions.slotResolutions }
-                    if (val === '') {
-                      delete newSlots.emissiveMap
-                    } else {
-                      newSlots.emissiveMap = Number(val)
-                    }
-                    onAtlasOptionsChange({ ...atlasOptions, slotResolutions: newSlots })
-                  }}
-                >
-                  <option value="">default</option>
-                  <option value={512}>512</option>
-                  <option value={1024}>1024</option>
-                  <option value={2048}>2048</option>
-                  <option value={4096}>4096</option>
-                </select>
+              <label className="vrm-check">
+                <input
+                  type="checkbox"
+                  checked={showPointLights}
+                  onChange={(e) => onShowPointLightsChange(e.target.checked)}
+                />
+                Point Lights
+              </label>
+              <label className="vrm-check">
+                <input
+                  type="checkbox"
+                  checked={logShaderInfo}
+                  onChange={(e) => onLogShaderInfoChange(e.target.checked)}
+                />
+                Log Shader
               </label>
             </div>
-          </div>
+          </Section>
 
-          {/* Simplify 統計パネル */}
-          {lastSimplifyStats && (
-            <div className="vrm-canvas__simplify-panel">
-              <div className="vrm-canvas__simplify-header">Simplify Stats</div>
-              <div className="vrm-canvas__simplify-stats">
-                <div>処理: {lastSimplifyStats.processedMeshCount} メッシュ (スキップ: {lastSimplifyStats.skippedMeshCount})</div>
-                <div>頂点: {lastSimplifyStats.originalVertexCount.toLocaleString()} → {lastSimplifyStats.simplifiedVertexCount.toLocaleString()} ({(lastSimplifyStats.vertexReductionRatio * 100).toFixed(1)}% 削減)</div>
-                <div>インデックス: {lastSimplifyStats.originalIndexCount.toLocaleString()} → {lastSimplifyStats.simplifiedIndexCount.toLocaleString()} ({(lastSimplifyStats.indexReductionRatio * 100).toFixed(1)}% 削減)</div>
-              </div>
-            </div>
-          )}
+          <Section title="アトラス解像度">
+            {ATLAS_SLOTS.map(({ key, label }) => (
+              <label className="vrm-field" key={key}>
+                <span className="vrm-field__label">{label}</span>
+                <select
+                  className="vrm-field__select"
+                  value={
+                    key === 'default'
+                      ? atlasOptions.defaultResolution ?? 2048
+                      : atlasOptions.slotResolutions?.[key] ?? ''
+                  }
+                  onChange={(e) => onAtlasOptionsChange(
+                    updateAtlasOption(atlasOptions, key, e.target.value)
+                  )}
+                >
+                  {key !== 'default' && <option value="">default</option>}
+                  {ATLAS_RESOLUTIONS.map((res) => (
+                    <option key={res} value={res}>{res}</option>
+                  ))}
+                </select>
+              </label>
+            ))}
+          </Section>
 
-          {/* 表情（モーフ）パネル */}
           {vrm?.expressionManager && (
-            <ExpressionPanel key={vrm.scene.uuid} vrm={vrm} />
+            <ExpressionSection key={vrm.scene.uuid} vrm={vrm} />
           )}
-        </>
+
+          <Section title="その他">
+            <button
+              className="vrm-btn"
+              onClick={onReplaceTextures}
+              disabled={!vrm || isReplacingTextures}
+            >
+              {isReplacingTextures ? 'Replacing...' : 'Replace Textures with UV'}
+            </button>
+            <button
+              className="vrm-btn"
+              onClick={onPlayAnimation}
+              disabled={!vrm || !!vrmAnimation}
+            >
+              {vrmAnimation ? 'Playing Animation' : 'Play Animation'}
+            </button>
+          </Section>
+
+          {(isSpectorReady || glRenderer) && (
+            <Section title="WebGL ツール">
+              {isSpectorReady && (
+                <div className="vrm-btn-row">
+                  <button className="vrm-btn vrm-btn--tool" onClick={captureFrame} title="Spector.jsでフレームをキャプチャ">
+                    Capture Frame
+                  </button>
+                  <button className="vrm-btn vrm-btn--tool" onClick={displaySpectorUI} title="Spector.js UIを表示">
+                    Spector UI
+                  </button>
+                </div>
+              )}
+              {glRenderer && (
+                <div className="vrm-btn-grid">
+                  <button className="vrm-btn vrm-btn--tool" onClick={handleListTextures} title="テクスチャ一覧をコンソール出力">
+                    List Tex
+                  </button>
+                  <button className="vrm-btn vrm-btn--tool" onClick={handleDumpFirstTexture} title="最初のテクスチャをBase64でコンソール出力">
+                    Dump Tex
+                  </button>
+                  <button className="vrm-btn vrm-btn--tool" onClick={handleDumpFramebuffer} title="フレームバッファをBase64でコンソール出力">
+                    Dump FB
+                  </button>
+                  <button className="vrm-btn vrm-btn--tool" onClick={handleDumpWebGLInfo} title="WebGL情報をコンソール出力">
+                    GL Info
+                  </button>
+                </div>
+              )}
+            </Section>
+          )}
+        </aside>
       )}
+
+      <div className="vrm-canvas__viewport">
+        <Canvas
+          shadows
+          camera={{
+            position: [0, 1.5, 3],
+            fov: 45,
+            near: 0.1,
+            far: 100,
+          }}
+          gl={{
+            antialias: true,
+            alpha: true,
+          }}
+          onCreated={({ gl }) =>
+          {
+            gl.shadowMap.type = 2 // THREE.PCFSoftShadowMap
+            setCanvasElement(gl.domElement)
+            setGlRenderer(gl)
+          }}
+        >
+          <CameraAspectUpdater />
+          <VRMScene vrm={vrm} vrmAnimation={vrmAnimation} debugMode={debugMode} springBoneEnabled={springBoneEnabled} showBones={showBones} showColliders={showColliders} showPointLights={showPointLights} logShaderInfo={logShaderInfo} />
+        </Canvas>
+
+        {currentTab === 0 && error && (
+          <div className="vrm-canvas__error">{error}</div>
+        )}
+
+        {currentTab === 0 && vrm && (
+          <div className="vrm-canvas__status">
+            VRM loaded: {vrm.scene.name || 'Unnamed Model'}
+          </div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 問題

3D Viewport タブの操作 UI が散らかっていて、実際に表示が壊れていた。

- ヘッダーがタイトル + セレクト + ボタン **11 個**を折り返しなしの 1 行 flex に詰め込んでおり、`Reload Export` と `Replace Textures with UV` が**右端で見切れていた**
- **CSS ルールが 0 件のクラスが 5 つ**あり、ブラウザ既定の見た目のまま表示されていた
  （`reload-export-btn` / `replace-textures-btn` / `play-animation-btn` / `pointlights-toggle` / `shaderlog-toggle`）
- Atlas パネルの `top: 70px` 固定がヘッダーの実際の高さを下回り、**ボタンの上に重なっていた**
- Debug パネルが select + チェックボックス 5 + ボタン 4 の区切りなしの縦一列

## 対応

操作系を左サイドバーの折りたたみセクションに集約し、ビューポートに重ねるのはエラー表示とステータスバーだけにした。

| セクション | 内容 | 既定 |
|---|---|---|
| モデル | モデル選択 / Upload VRM | 開 |
| 最適化 | Optimize + Migrate / Optimize / Migrate / Simplify Only / Simplify 統計 | 開 |
| エクスポート | Export VRM / Reload Export / Export Scene / Last export | 開 |
| 表示設定 | Debug Mode + チェックボックス 5 | 閉 |
| アトラス解像度 | Default / map / normalMap / emissiveMap | 閉 |
| 表情 (n) | スライダー（内部スクロール） | 閉 |
| その他 | Replace Textures with UV / Play Animation | 閉 |
| WebGL ツール | Capture Frame / Spector UI / List Tex / Dump Tex / Dump FB / GL Info | 閉 |

ルートを 2 カラム flex にしたので、サイドバーとビューポートが重なることはなくなった。ボタン色のインライン `style` も CSS クラスへ移した。

**機能の増減はない。** 全ハンドラ（ボタン・セレクト・チェックボックス・隠しファイル入力）の残存をスクリプトで照合済み。

## リファクタ

- 折りたたみ用の `Section` コンポーネントを追加
- Debug Mode の説明文 → `DEBUG_MODE_HINTS`（`{debugMode === 'xxx' && '...'}` の 12 連を置き換え）
- アトラス解像度 4 スロットぶんのほぼ同一 JSX 約 90 行 → `ATLAS_SLOTS` + `updateAtlasOption`

`DEBUG_MODE_HINTS` は `Record<DebugMode, string>` で型付けしたため、**tsc が通ること自体が全モードぶんの説明文が揃っている保証**になる。実際これで `alpha` の説明文が元から抜けていたことが判明したので追加した。

## 動作確認

debug-viewer を実際に動かして確認。

- 全 8 セクションが開閉し、中身が見切れない
- Optimize + Migrate → Reload Export が **6.97 MB** で成功、コンソールエラー 0 件
- 3D Viewport → Textures → 3D Viewport でセクションの開閉状態が保たれる

`tsc --noEmit` は clean。eslint はこのファイルで 2 件エラーが出るが、どちらも `main` の時点から存在するもので本 PR の変更由来ではない（`set-state-in-effect` / `immutability`）。

## 補足

WebGL デバッグ用ボタンが折りたたみセクション配下に移り、開くまで DOM に存在しなくなったため、`packages/debug-viewer/CLAUDE.md` に書かれていた Playwright MCP の手順を更新した（セクションを開くステップの追加と、壊れていた固定 `ref` のテキストセレクタ化）。

レビューで「表示設定 も既定で開いた方が良いのでは」という案が出ています。SpringBone トグルと Debug Mode は使用頻度が高いので一理あると思いますが、いったん閉じたままにしています。ご意見ください。
